### PR TITLE
Add Several bitbake features

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,9 +1,58 @@
-"inherit" @keyword
+[
+    "inherit"
+    "export"
+    "unset"
+    "include"
+    "require"
+    "EXPORT_FUNCTIONS"
+    "addtask"
+    "before"
+    "after"
+    "deltask"
+    "addhandler"
+] @keyword
 
-(task_declaration name: (identifier) @function)
+(shell_task_declaration name: (identifier) @function)
+(shell_task_declaration [ "(" ")" ] @punctuation.bracket)
+(python_task_declaration name: (identifier) @function)
+(python_task_declaration "python" @keyword)
+(python_task_declaration [ "(" ")" ] @punctuation.bracket)
+
+(block [ "{" "}" ] @punctuation.bracket)
+
+(shell_expansion [ "${" "}" ] @punctuation.bracket)
+(python_expansion [ "${@" "}" ] @punctuation.bracket)
 
 (string) @string
+(shell_expansion) @none
+(shell_expansion (variable_name) @variable)
+(python_expansion (inline_code) @none)
+
+(inherit) @string
+(inherit (class_name) @type)
+(include) @string
+
+(variable_declaration (identifier (variable_name) @constant))
+(export (variable_name) @constant)
+(unset (variable_name) @constant)
+
+(addtask (function_name) @function)
+(deltask (function_name) @function)
+(addhandler (function_name) @function)
+(export_functions (function_name) @function)
+
+(override) @attribute
+(override ":" @punctuation.delimiter)
+
+(override [ "append" "prepend" "remove" ] @constant.builtin)
+
+(flag [ "[" "]" ] @punctuation.bracket)
+(flag (flag_name) @none)
+(flag (flag_name) @variable)
 
 [
     "="
 ] @operator
+
+(comment) @comment
+(ERROR) @error

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,9 @@
+(shell_task_declaration (block (code_body) @injection.content (#set! injection.language "bash")))
+(python_task_declaration (block (code_body) @injection.content (#set! injection.language "python")))
+
+(shell_task_declaration (block (code_body) @injection.content (#set! injection.language "bash")))
+(python_task_declaration (block (code_body) @injection.content (#set! injection.language "python")))
+(python_expansion (inline_code) @injection.content (#set! injection.language "python"))
+(python_function) @injection.content (#set! injection.language "python")
+
+(comment) @injection.content (#set! injection.language "comment")

--- a/readme.md
+++ b/readme.md
@@ -2,10 +2,3 @@ tree-sitter-bb
 =================
 
 A bitbake grammar for tree-sitter.
-
-
-Known limits:
-
-1. Nesting variable/expression expansions inside of variable/expression expansions.
-1. Strange quoting behavior.
-1. python def blocks.

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -17,11 +17,15 @@
         },
         {
           "type": "SYMBOL",
-          "name": "require"
+          "name": "addtask"
         },
         {
           "type": "SYMBOL",
-          "name": "addtask"
+          "name": "deltask"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "addhandler"
         },
         {
           "type": "SYMBOL",
@@ -29,7 +33,19 @@
         },
         {
           "type": "SYMBOL",
+          "name": "unset"
+        },
+        {
+          "type": "SYMBOL",
           "name": "include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "export_functions"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "shell_task_declaration"
         },
         {
           "type": "SYMBOL",
@@ -37,11 +53,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "task_declaration"
+          "name": "variable_declaration"
         },
         {
           "type": "SYMBOL",
-          "name": "variable_declaration"
+          "name": "python_function"
         },
         {
           "type": "SYMBOL",
@@ -111,7 +127,7 @@
         }
       ]
     },
-    "task_declaration": {
+    "shell_task_declaration": {
       "type": "SEQ",
       "members": [
         {
@@ -144,8 +160,37 @@
           "value": "python"
         },
         {
-          "type": "SYMBOL",
-          "name": "task_declaration"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "FIELD",
+                  "name": "name",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  }
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "block"
+            }
+          ]
         }
       ]
     },
@@ -157,11 +202,16 @@
           "value": "{"
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "statement"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "code_body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",
@@ -169,14 +219,17 @@
         }
       ]
     },
-    "statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "PATTERN",
-          "value": "[^\\n]+"
-        }
-      ]
+    "code_body": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "PATTERN",
+            "value": "[^\\n]+"
+          }
+        ]
+      }
     },
     "inherit": {
       "type": "SEQ",
@@ -188,8 +241,8 @@
         {
           "type": "REPEAT1",
           "content": {
-            "type": "PATTERN",
-            "value": "[^ \\n]+"
+            "type": "SYMBOL",
+            "name": "class_name"
           }
         },
         {
@@ -198,34 +251,23 @@
         }
       ]
     },
-    "require": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "require"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_require_path"
-        },
-        {
-          "type": "STRING",
-          "value": "\n"
-        }
-      ]
+    "class_name": {
+      "type": "ALIAS",
+      "content": {
+        "type": "SYMBOL",
+        "name": "variable_name"
+      },
+      "named": false,
+      "value": ""
     },
-    "_require_path": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "REPEAT1",
-          "content": {
-            "type": "PATTERN",
-            "value": "[^\\n]*"
-          }
-        }
-      ]
+    "function_name": {
+      "type": "ALIAS",
+      "content": {
+        "type": "SYMBOL",
+        "name": "variable_name"
+      },
+      "named": false,
+      "value": ""
     },
     "addtask": {
       "type": "SEQ",
@@ -237,8 +279,61 @@
         {
           "type": "REPEAT1",
           "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "after"
+              },
+              {
+                "type": "STRING",
+                "value": "before"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "function_name"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\n"
+        }
+      ]
+    },
+    "deltask": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "deltask"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "function_name"
+          }
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\n"
+        }
+      ]
+    },
+    "addhandler": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "addhandler"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "SYMBOL",
+            "name": "function_name"
           }
         },
         {
@@ -258,7 +353,27 @@
           "type": "REPEAT1",
           "content": {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "variable_name"
+          }
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\n"
+        }
+      ]
+    },
+    "unset": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "unset"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "SYMBOL",
+            "name": "variable_name"
           }
         },
         {
@@ -271,12 +386,76 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "include"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "include"
+            },
+            {
+              "type": "STRING",
+              "value": "require"
+            }
+          ]
         },
         {
           "type": "PATTERN",
-          "value": "[^ \\n]+"
+          "value": "\\s+"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_include_path_fragment"
+            }
+          },
+          "named": true,
+          "value": "path"
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\n"
+        }
+      ]
+    },
+    "_include_path_fragment": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_expansion"
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "\\$[^{]"
+          }
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "[^$\\n]+"
+          }
+        }
+      ]
+    },
+    "export_functions": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "EXPORT_FUNCTIONS"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "SYMBOL",
+            "name": "function_name"
+          }
         },
         {
           "type": "PATTERN",
@@ -295,67 +474,124 @@
               "value": "\""
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "string_expansion"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "string_escape"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\"]"
-                  }
-                ]
-              }
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_string_inner1"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
-              "type": "STRING",
-              "value": "\""
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "\""
+              }
             }
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "string2"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "'"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_string_inner2"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "'"
+              }
+            }
+          ]
         }
       ]
     },
-    "string2": {
+    "_string_inner1": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expansion"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "string_text_fragment1"
+            },
+            "named": true,
+            "value": "string_text_fragment"
+          }
+        ]
+      }
+    },
+    "_string_inner2": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expansion"
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "string_text_fragment2"
+            },
+            "named": true,
+            "value": "string_text_fragment"
+          }
+        ]
+      }
+    },
+    "_expansion": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "python_expansion"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "shell_expansion"
+        }
+      ]
+    },
+    "python_expansion": {
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "'"
-        },
-        {
-          "type": "REPEAT",
+          "type": "IMMEDIATE_TOKEN",
           "content": {
-            "type": "PATTERN",
-            "value": "[^']"
+            "type": "STRING",
+            "value": "${@"
           }
         },
         {
-          "type": "STRING",
-          "value": "'"
-        }
-      ]
-    },
-    "string_expansion": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "${"
-        },
-        {
-          "type": "PATTERN",
-          "value": "[^}]*"
+          "type": "SYMBOL",
+          "name": "inline_code"
         },
         {
           "type": "STRING",
@@ -363,18 +599,104 @@
         }
       ]
     },
-    "string_escape": {
-      "type": "SEQ",
+    "inline_code": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_inline_code_inner"
+      }
+    },
+    "_inline_code_inner": {
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "\\\\"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "{"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_inline_code_inner"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "}"
+            }
+          ]
         },
         {
           "type": "PATTERN",
-          "value": "\""
+          "value": "[^{}]+"
         }
       ]
+    },
+    "shell_expansion": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "${"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "variable_name"
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "string_text_fragment1": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "([^\"$\\n]|\\\\\\n)+"
+      }
+    },
+    "string_text_fragment2": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "([^'$\\n]|\\\\\\n)+"
+      }
+    },
+    "flag": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "["
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "flag_name"
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "flag_name": {
+      "type": "PATTERN",
+      "value": "[^\\]]+"
     },
     "override": {
       "type": "PREC",
@@ -383,31 +705,165 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "STRING",
-            "value": ":"
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "STRING",
+              "value": ":"
+            }
           },
           {
-            "type": "PATTERN",
-            "value": "[a-zA-Z0-9_${}\\-]+"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "append"
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "prepend"
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "remove"
+                }
+              },
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_override_fragment"
+                }
+              }
+            ]
           }
         ]
       }
+    },
+    "_override_fragment": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_expansion"
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "\\$[^{]"
+          }
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "[a-zA-Z0-9_{}\\-]+"
+          }
+        }
+      ]
     },
     "identifier": {
       "type": "SEQ",
       "members": [
         {
+          "type": "SYMBOL",
+          "name": "variable_name"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "flag"
+                },
+                {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "override"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "variable_name": {
+      "type": "SEQ",
+      "members": [
+        {
           "type": "PATTERN",
-          "value": "[@A-Za-z0-9_{}$\\-\\[\\]\\.]+"
+          "value": "[a-zA-Z0-9_\\-\\.]+"
         },
         {
           "type": "REPEAT",
           "content": {
             "type": "SYMBOL",
-            "name": "override"
+            "name": "_variable_fragment"
           }
         }
       ]
+    },
+    "_variable_fragment": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_expansion"
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "\\$[^{]"
+          }
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "[a-zA-Z0-9_\\-\\.]+"
+          }
+        }
+      ]
+    },
+    "python_function": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "def"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_python_code"
+          }
+        }
+      ]
+    },
+    "_python_code": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "([ \\t].+|)\\n"
+      }
     },
     "comment": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,6 +1,25 @@
 [
   {
-    "type": "addtask",
+    "type": "",
+    "named": false,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "python_expansion",
+          "named": true
+        },
+        {
+          "type": "shell_expansion",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "addhandler",
     "named": true,
     "fields": {},
     "children": {
@@ -8,7 +27,22 @@
       "required": true,
       "types": [
         {
-          "type": "identifier",
+          "type": "function_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "addtask",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "function_name",
           "named": true
         }
       ]
@@ -19,20 +53,45 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "types": [
         {
-          "type": "statement",
+          "type": "code_body",
           "named": true
         }
       ]
     }
   },
   {
+    "type": "class_name",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "code_body",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "comment",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "deltask",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "function_name",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "export",
@@ -43,11 +102,46 @@
       "required": true,
       "types": [
         {
-          "type": "identifier",
+          "type": "variable_name",
           "named": true
         }
       ]
     }
+  },
+  {
+    "type": "export_functions",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "function_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "flag",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "flag_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_name",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "identifier",
@@ -55,10 +149,18 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
+          "type": "flag",
+          "named": true
+        },
+        {
           "type": "override",
+          "named": true
+        },
+        {
+          "type": "variable_name",
           "named": true
         }
       ]
@@ -67,20 +169,78 @@
   {
     "type": "include",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "path",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "inherit",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "class_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "inline_code",
     "named": true,
     "fields": {}
   },
   {
     "type": "override",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "python_expansion",
+          "named": true
+        },
+        {
+          "type": "shell_expansion",
+          "named": true
+        }
+      ]
+    }
   },
   {
-    "type": "python_task_declaration",
+    "type": "path",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "python_expansion",
+          "named": true
+        },
+        {
+          "type": "shell_expansion",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "python_expansion",
     "named": true,
     "fields": {},
     "children": {
@@ -88,109 +248,60 @@
       "required": true,
       "types": [
         {
-          "type": "task_declaration",
+          "type": "inline_code",
           "named": true
         }
       ]
     }
   },
   {
-    "type": "require",
+    "type": "python_function",
     "named": true,
     "fields": {}
   },
   {
-    "type": "source_file",
+    "type": "python_task_declaration",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "block",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "shell_expansion",
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
-      "required": false,
+      "multiple": false,
+      "required": true,
       "types": [
         {
-          "type": "addtask",
-          "named": true
-        },
-        {
-          "type": "comment",
-          "named": true
-        },
-        {
-          "type": "export",
-          "named": true
-        },
-        {
-          "type": "include",
-          "named": true
-        },
-        {
-          "type": "inherit",
-          "named": true
-        },
-        {
-          "type": "python_task_declaration",
-          "named": true
-        },
-        {
-          "type": "require",
-          "named": true
-        },
-        {
-          "type": "task_declaration",
-          "named": true
-        },
-        {
-          "type": "variable_declaration",
+          "type": "variable_name",
           "named": true
         }
       ]
     }
   },
   {
-    "type": "statement",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "string",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "string2",
-          "named": true
-        },
-        {
-          "type": "string_escape",
-          "named": true
-        },
-        {
-          "type": "string_expansion",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "string2",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "string_escape",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "string_expansion",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "task_declaration",
+    "type": "shell_task_declaration",
     "named": true,
     "fields": {
       "name": {
@@ -216,6 +327,107 @@
     }
   },
   {
+    "type": "source_file",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "addhandler",
+          "named": true
+        },
+        {
+          "type": "addtask",
+          "named": true
+        },
+        {
+          "type": "comment",
+          "named": true
+        },
+        {
+          "type": "deltask",
+          "named": true
+        },
+        {
+          "type": "export",
+          "named": true
+        },
+        {
+          "type": "export_functions",
+          "named": true
+        },
+        {
+          "type": "include",
+          "named": true
+        },
+        {
+          "type": "inherit",
+          "named": true
+        },
+        {
+          "type": "python_function",
+          "named": true
+        },
+        {
+          "type": "python_task_declaration",
+          "named": true
+        },
+        {
+          "type": "shell_task_declaration",
+          "named": true
+        },
+        {
+          "type": "unset",
+          "named": true
+        },
+        {
+          "type": "variable_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "string",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "python_expansion",
+          "named": true
+        },
+        {
+          "type": "shell_expansion",
+          "named": true
+        },
+        {
+          "type": "string_text_fragment",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "unset",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "variable_name",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "variable_declaration",
     "named": true,
     "fields": {},
@@ -235,6 +447,25 @@
     }
   },
   {
+    "type": "variable_name",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "python_expansion",
+          "named": true
+        },
+        {
+          "type": "shell_expansion",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "\n",
     "named": false
   },
@@ -248,6 +479,10 @@
   },
   {
     "type": "${",
+    "named": false
+  },
+  {
+    "type": "${@",
     "named": false
   },
   {
@@ -299,7 +534,19 @@
     "named": false
   },
   {
-    "type": "\\\\",
+    "type": "EXPORT_FUNCTIONS",
+    "named": false
+  },
+  {
+    "type": "[",
+    "named": false
+  },
+  {
+    "type": "]",
+    "named": false
+  },
+  {
+    "type": "addhandler",
     "named": false
   },
   {
@@ -307,8 +554,32 @@
     "named": false
   },
   {
+    "type": "after",
+    "named": false
+  },
+  {
+    "type": "append",
+    "named": false
+  },
+  {
+    "type": "before",
+    "named": false
+  },
+  {
+    "type": "def",
+    "named": false
+  },
+  {
+    "type": "deltask",
+    "named": false
+  },
+  {
     "type": "export",
     "named": false
+  },
+  {
+    "type": "flag_name",
+    "named": true
   },
   {
     "type": "include",
@@ -319,11 +590,27 @@
     "named": false
   },
   {
+    "type": "prepend",
+    "named": false
+  },
+  {
     "type": "python",
     "named": false
   },
   {
+    "type": "remove",
+    "named": false
+  },
+  {
     "type": "require",
+    "named": false
+  },
+  {
+    "type": "string_text_fragment",
+    "named": true
+  },
+  {
+    "type": "unset",
     "named": false
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,16 +5,24 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
+#ifdef _MSC_VER
+#pragma optimize("", off)
+#elif defined(__clang__)
+#pragma clang optimize off
+#elif defined(__GNUC__)
+#pragma GCC optimize ("O0")
+#endif
+
 #define LANGUAGE_VERSION 13
-#define STATE_COUNT 75
+#define STATE_COUNT 175
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 65
-#define ALIAS_COUNT 0
-#define TOKEN_COUNT 37
+#define SYMBOL_COUNT 100
+#define ALIAS_COUNT 2
+#define TOKEN_COUNT 54
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 1
-#define MAX_ALIAS_SEQUENCE_LENGTH 4
-#define PRODUCTION_ID_COUNT 2
+#define MAX_ALIAS_SEQUENCE_LENGTH 5
+#define PRODUCTION_ID_COUNT 5
 
 enum {
   anon_sym_export = 1,
@@ -31,56 +39,93 @@ enum {
   anon_sym_python = 12,
   anon_sym_LBRACE = 13,
   anon_sym_RBRACE = 14,
-  aux_sym_statement_token1 = 15,
+  aux_sym_code_body_token1 = 15,
   anon_sym_inherit = 16,
-  aux_sym_inherit_token1 = 17,
-  anon_sym_LF = 18,
-  anon_sym_require = 19,
-  aux_sym__require_path_token1 = 20,
-  anon_sym_addtask = 21,
-  aux_sym_addtask_token1 = 22,
-  anon_sym_include = 23,
-  anon_sym_DQUOTE = 24,
-  aux_sym_string_token1 = 25,
-  anon_sym_SQUOTE = 26,
-  aux_sym_string2_token1 = 27,
-  anon_sym_DOLLAR_LBRACE = 28,
-  aux_sym_string_expansion_token1 = 29,
-  anon_sym_BSLASH_BSLASH = 30,
-  aux_sym_string_escape_token1 = 31,
-  anon_sym_COLON = 32,
-  aux_sym_override_token1 = 33,
-  aux_sym_identifier_token1 = 34,
-  anon_sym_POUND = 35,
-  aux_sym_comment_token1 = 36,
-  sym_source_file = 37,
-  sym__declaration = 38,
-  sym_variable_declaration = 39,
-  sym_task_declaration = 40,
-  sym_python_task_declaration = 41,
-  sym_block = 42,
-  sym_statement = 43,
-  sym_inherit = 44,
-  sym_require = 45,
-  sym__require_path = 46,
-  sym_addtask = 47,
-  sym_export = 48,
-  sym_include = 49,
-  sym_string = 50,
-  sym_string2 = 51,
-  sym_string_expansion = 52,
-  sym_string_escape = 53,
-  sym_override = 54,
-  sym_identifier = 55,
-  sym_comment = 56,
-  aux_sym_source_file_repeat1 = 57,
-  aux_sym_block_repeat1 = 58,
-  aux_sym_inherit_repeat1 = 59,
-  aux_sym__require_path_repeat1 = 60,
-  aux_sym_addtask_repeat1 = 61,
-  aux_sym_string_repeat1 = 62,
-  aux_sym_string2_repeat1 = 63,
-  aux_sym_identifier_repeat1 = 64,
+  anon_sym_LF = 17,
+  anon_sym_addtask = 18,
+  anon_sym_after = 19,
+  anon_sym_before = 20,
+  aux_sym_addtask_token1 = 21,
+  anon_sym_deltask = 22,
+  anon_sym_addhandler = 23,
+  anon_sym_unset = 24,
+  anon_sym_include = 25,
+  anon_sym_require = 26,
+  aux_sym_include_token1 = 27,
+  aux_sym__include_path_fragment_token1 = 28,
+  aux_sym__include_path_fragment_token2 = 29,
+  anon_sym_EXPORT_FUNCTIONS = 30,
+  anon_sym_DQUOTE = 31,
+  anon_sym_DQUOTE2 = 32,
+  anon_sym_SQUOTE = 33,
+  anon_sym_SQUOTE2 = 34,
+  anon_sym_DOLLAR_LBRACE_AT = 35,
+  aux_sym__inline_code_inner_token1 = 36,
+  anon_sym_DOLLAR_LBRACE = 37,
+  sym_string_text_fragment1 = 38,
+  sym_string_text_fragment2 = 39,
+  anon_sym_LBRACK = 40,
+  anon_sym_RBRACK = 41,
+  sym_flag_name = 42,
+  anon_sym_COLON = 43,
+  anon_sym_append = 44,
+  anon_sym_prepend = 45,
+  anon_sym_remove = 46,
+  aux_sym__override_fragment_token1 = 47,
+  aux_sym_variable_name_token1 = 48,
+  aux_sym__variable_fragment_token1 = 49,
+  anon_sym_def = 50,
+  sym__python_code = 51,
+  anon_sym_POUND = 52,
+  aux_sym_comment_token1 = 53,
+  sym_source_file = 54,
+  sym__declaration = 55,
+  sym_variable_declaration = 56,
+  sym_shell_task_declaration = 57,
+  sym_python_task_declaration = 58,
+  sym_block = 59,
+  sym_code_body = 60,
+  sym_inherit = 61,
+  sym_class_name = 62,
+  sym_function_name = 63,
+  sym_addtask = 64,
+  sym_deltask = 65,
+  sym_addhandler = 66,
+  sym_export = 67,
+  sym_unset = 68,
+  sym_include = 69,
+  sym__include_path_fragment = 70,
+  sym_export_functions = 71,
+  sym_string = 72,
+  aux_sym__string_inner1 = 73,
+  aux_sym__string_inner2 = 74,
+  sym__expansion = 75,
+  sym_python_expansion = 76,
+  sym_inline_code = 77,
+  sym__inline_code_inner = 78,
+  sym_shell_expansion = 79,
+  sym_flag = 80,
+  sym_override = 81,
+  sym__override_fragment = 82,
+  sym_identifier = 83,
+  sym_variable_name = 84,
+  sym__variable_fragment = 85,
+  sym_python_function = 86,
+  sym_comment = 87,
+  aux_sym_source_file_repeat1 = 88,
+  aux_sym_code_body_repeat1 = 89,
+  aux_sym_inherit_repeat1 = 90,
+  aux_sym_addtask_repeat1 = 91,
+  aux_sym_deltask_repeat1 = 92,
+  aux_sym_export_repeat1 = 93,
+  aux_sym_include_repeat1 = 94,
+  aux_sym_inline_code_repeat1 = 95,
+  aux_sym_override_repeat1 = 96,
+  aux_sym_identifier_repeat1 = 97,
+  aux_sym_variable_name_repeat1 = 98,
+  aux_sym_python_function_repeat1 = 99,
+  anon_alias_sym_ = 100,
+  alias_sym_path = 101,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -99,56 +144,93 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_python] = "python",
   [anon_sym_LBRACE] = "{",
   [anon_sym_RBRACE] = "}",
-  [aux_sym_statement_token1] = "statement_token1",
+  [aux_sym_code_body_token1] = "code_body_token1",
   [anon_sym_inherit] = "inherit",
-  [aux_sym_inherit_token1] = "inherit_token1",
   [anon_sym_LF] = "\n",
-  [anon_sym_require] = "require",
-  [aux_sym__require_path_token1] = "_require_path_token1",
   [anon_sym_addtask] = "addtask",
+  [anon_sym_after] = "after",
+  [anon_sym_before] = "before",
   [aux_sym_addtask_token1] = "addtask_token1",
+  [anon_sym_deltask] = "deltask",
+  [anon_sym_addhandler] = "addhandler",
+  [anon_sym_unset] = "unset",
   [anon_sym_include] = "include",
+  [anon_sym_require] = "require",
+  [aux_sym_include_token1] = "include_token1",
+  [aux_sym__include_path_fragment_token1] = "_include_path_fragment_token1",
+  [aux_sym__include_path_fragment_token2] = "_include_path_fragment_token2",
+  [anon_sym_EXPORT_FUNCTIONS] = "EXPORT_FUNCTIONS",
   [anon_sym_DQUOTE] = "\"",
-  [aux_sym_string_token1] = "string_token1",
+  [anon_sym_DQUOTE2] = "\"",
   [anon_sym_SQUOTE] = "'",
-  [aux_sym_string2_token1] = "string2_token1",
+  [anon_sym_SQUOTE2] = "'",
+  [anon_sym_DOLLAR_LBRACE_AT] = "${@",
+  [aux_sym__inline_code_inner_token1] = "_inline_code_inner_token1",
   [anon_sym_DOLLAR_LBRACE] = "${",
-  [aux_sym_string_expansion_token1] = "string_expansion_token1",
-  [anon_sym_BSLASH_BSLASH] = "\\\\",
-  [aux_sym_string_escape_token1] = "string_escape_token1",
+  [sym_string_text_fragment1] = "string_text_fragment",
+  [sym_string_text_fragment2] = "string_text_fragment",
+  [anon_sym_LBRACK] = "[",
+  [anon_sym_RBRACK] = "]",
+  [sym_flag_name] = "flag_name",
   [anon_sym_COLON] = ":",
-  [aux_sym_override_token1] = "override_token1",
-  [aux_sym_identifier_token1] = "identifier_token1",
+  [anon_sym_append] = "append",
+  [anon_sym_prepend] = "prepend",
+  [anon_sym_remove] = "remove",
+  [aux_sym__override_fragment_token1] = "_override_fragment_token1",
+  [aux_sym_variable_name_token1] = "variable_name_token1",
+  [aux_sym__variable_fragment_token1] = "_variable_fragment_token1",
+  [anon_sym_def] = "def",
+  [sym__python_code] = "_python_code",
   [anon_sym_POUND] = "#",
   [aux_sym_comment_token1] = "comment_token1",
   [sym_source_file] = "source_file",
   [sym__declaration] = "_declaration",
   [sym_variable_declaration] = "variable_declaration",
-  [sym_task_declaration] = "task_declaration",
+  [sym_shell_task_declaration] = "shell_task_declaration",
   [sym_python_task_declaration] = "python_task_declaration",
   [sym_block] = "block",
-  [sym_statement] = "statement",
+  [sym_code_body] = "code_body",
   [sym_inherit] = "inherit",
-  [sym_require] = "require",
-  [sym__require_path] = "_require_path",
+  [sym_class_name] = "class_name",
+  [sym_function_name] = "function_name",
   [sym_addtask] = "addtask",
+  [sym_deltask] = "deltask",
+  [sym_addhandler] = "addhandler",
   [sym_export] = "export",
+  [sym_unset] = "unset",
   [sym_include] = "include",
+  [sym__include_path_fragment] = "_include_path_fragment",
+  [sym_export_functions] = "export_functions",
   [sym_string] = "string",
-  [sym_string2] = "string2",
-  [sym_string_expansion] = "string_expansion",
-  [sym_string_escape] = "string_escape",
+  [aux_sym__string_inner1] = "_string_inner1",
+  [aux_sym__string_inner2] = "_string_inner2",
+  [sym__expansion] = "_expansion",
+  [sym_python_expansion] = "python_expansion",
+  [sym_inline_code] = "inline_code",
+  [sym__inline_code_inner] = "_inline_code_inner",
+  [sym_shell_expansion] = "shell_expansion",
+  [sym_flag] = "flag",
   [sym_override] = "override",
+  [sym__override_fragment] = "_override_fragment",
   [sym_identifier] = "identifier",
+  [sym_variable_name] = "variable_name",
+  [sym__variable_fragment] = "_variable_fragment",
+  [sym_python_function] = "python_function",
   [sym_comment] = "comment",
   [aux_sym_source_file_repeat1] = "source_file_repeat1",
-  [aux_sym_block_repeat1] = "block_repeat1",
+  [aux_sym_code_body_repeat1] = "code_body_repeat1",
   [aux_sym_inherit_repeat1] = "inherit_repeat1",
-  [aux_sym__require_path_repeat1] = "_require_path_repeat1",
   [aux_sym_addtask_repeat1] = "addtask_repeat1",
-  [aux_sym_string_repeat1] = "string_repeat1",
-  [aux_sym_string2_repeat1] = "string2_repeat1",
+  [aux_sym_deltask_repeat1] = "deltask_repeat1",
+  [aux_sym_export_repeat1] = "export_repeat1",
+  [aux_sym_include_repeat1] = "include_repeat1",
+  [aux_sym_inline_code_repeat1] = "inline_code_repeat1",
+  [aux_sym_override_repeat1] = "override_repeat1",
   [aux_sym_identifier_repeat1] = "identifier_repeat1",
+  [aux_sym_variable_name_repeat1] = "variable_name_repeat1",
+  [aux_sym_python_function_repeat1] = "python_function_repeat1",
+  [anon_alias_sym_] = "",
+  [alias_sym_path] = "path",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -167,56 +249,93 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_python] = anon_sym_python,
   [anon_sym_LBRACE] = anon_sym_LBRACE,
   [anon_sym_RBRACE] = anon_sym_RBRACE,
-  [aux_sym_statement_token1] = aux_sym_statement_token1,
+  [aux_sym_code_body_token1] = aux_sym_code_body_token1,
   [anon_sym_inherit] = anon_sym_inherit,
-  [aux_sym_inherit_token1] = aux_sym_inherit_token1,
   [anon_sym_LF] = anon_sym_LF,
-  [anon_sym_require] = anon_sym_require,
-  [aux_sym__require_path_token1] = aux_sym__require_path_token1,
   [anon_sym_addtask] = anon_sym_addtask,
+  [anon_sym_after] = anon_sym_after,
+  [anon_sym_before] = anon_sym_before,
   [aux_sym_addtask_token1] = aux_sym_addtask_token1,
+  [anon_sym_deltask] = anon_sym_deltask,
+  [anon_sym_addhandler] = anon_sym_addhandler,
+  [anon_sym_unset] = anon_sym_unset,
   [anon_sym_include] = anon_sym_include,
+  [anon_sym_require] = anon_sym_require,
+  [aux_sym_include_token1] = aux_sym_include_token1,
+  [aux_sym__include_path_fragment_token1] = aux_sym__include_path_fragment_token1,
+  [aux_sym__include_path_fragment_token2] = aux_sym__include_path_fragment_token2,
+  [anon_sym_EXPORT_FUNCTIONS] = anon_sym_EXPORT_FUNCTIONS,
   [anon_sym_DQUOTE] = anon_sym_DQUOTE,
-  [aux_sym_string_token1] = aux_sym_string_token1,
+  [anon_sym_DQUOTE2] = anon_sym_DQUOTE,
   [anon_sym_SQUOTE] = anon_sym_SQUOTE,
-  [aux_sym_string2_token1] = aux_sym_string2_token1,
+  [anon_sym_SQUOTE2] = anon_sym_SQUOTE,
+  [anon_sym_DOLLAR_LBRACE_AT] = anon_sym_DOLLAR_LBRACE_AT,
+  [aux_sym__inline_code_inner_token1] = aux_sym__inline_code_inner_token1,
   [anon_sym_DOLLAR_LBRACE] = anon_sym_DOLLAR_LBRACE,
-  [aux_sym_string_expansion_token1] = aux_sym_string_expansion_token1,
-  [anon_sym_BSLASH_BSLASH] = anon_sym_BSLASH_BSLASH,
-  [aux_sym_string_escape_token1] = aux_sym_string_escape_token1,
+  [sym_string_text_fragment1] = sym_string_text_fragment1,
+  [sym_string_text_fragment2] = sym_string_text_fragment1,
+  [anon_sym_LBRACK] = anon_sym_LBRACK,
+  [anon_sym_RBRACK] = anon_sym_RBRACK,
+  [sym_flag_name] = sym_flag_name,
   [anon_sym_COLON] = anon_sym_COLON,
-  [aux_sym_override_token1] = aux_sym_override_token1,
-  [aux_sym_identifier_token1] = aux_sym_identifier_token1,
+  [anon_sym_append] = anon_sym_append,
+  [anon_sym_prepend] = anon_sym_prepend,
+  [anon_sym_remove] = anon_sym_remove,
+  [aux_sym__override_fragment_token1] = aux_sym__override_fragment_token1,
+  [aux_sym_variable_name_token1] = aux_sym_variable_name_token1,
+  [aux_sym__variable_fragment_token1] = aux_sym__variable_fragment_token1,
+  [anon_sym_def] = anon_sym_def,
+  [sym__python_code] = sym__python_code,
   [anon_sym_POUND] = anon_sym_POUND,
   [aux_sym_comment_token1] = aux_sym_comment_token1,
   [sym_source_file] = sym_source_file,
   [sym__declaration] = sym__declaration,
   [sym_variable_declaration] = sym_variable_declaration,
-  [sym_task_declaration] = sym_task_declaration,
+  [sym_shell_task_declaration] = sym_shell_task_declaration,
   [sym_python_task_declaration] = sym_python_task_declaration,
   [sym_block] = sym_block,
-  [sym_statement] = sym_statement,
+  [sym_code_body] = sym_code_body,
   [sym_inherit] = sym_inherit,
-  [sym_require] = sym_require,
-  [sym__require_path] = sym__require_path,
+  [sym_class_name] = sym_class_name,
+  [sym_function_name] = sym_function_name,
   [sym_addtask] = sym_addtask,
+  [sym_deltask] = sym_deltask,
+  [sym_addhandler] = sym_addhandler,
   [sym_export] = sym_export,
+  [sym_unset] = sym_unset,
   [sym_include] = sym_include,
+  [sym__include_path_fragment] = sym__include_path_fragment,
+  [sym_export_functions] = sym_export_functions,
   [sym_string] = sym_string,
-  [sym_string2] = sym_string2,
-  [sym_string_expansion] = sym_string_expansion,
-  [sym_string_escape] = sym_string_escape,
+  [aux_sym__string_inner1] = aux_sym__string_inner1,
+  [aux_sym__string_inner2] = aux_sym__string_inner2,
+  [sym__expansion] = sym__expansion,
+  [sym_python_expansion] = sym_python_expansion,
+  [sym_inline_code] = sym_inline_code,
+  [sym__inline_code_inner] = sym__inline_code_inner,
+  [sym_shell_expansion] = sym_shell_expansion,
+  [sym_flag] = sym_flag,
   [sym_override] = sym_override,
+  [sym__override_fragment] = sym__override_fragment,
   [sym_identifier] = sym_identifier,
+  [sym_variable_name] = sym_variable_name,
+  [sym__variable_fragment] = sym__variable_fragment,
+  [sym_python_function] = sym_python_function,
   [sym_comment] = sym_comment,
   [aux_sym_source_file_repeat1] = aux_sym_source_file_repeat1,
-  [aux_sym_block_repeat1] = aux_sym_block_repeat1,
+  [aux_sym_code_body_repeat1] = aux_sym_code_body_repeat1,
   [aux_sym_inherit_repeat1] = aux_sym_inherit_repeat1,
-  [aux_sym__require_path_repeat1] = aux_sym__require_path_repeat1,
   [aux_sym_addtask_repeat1] = aux_sym_addtask_repeat1,
-  [aux_sym_string_repeat1] = aux_sym_string_repeat1,
-  [aux_sym_string2_repeat1] = aux_sym_string2_repeat1,
+  [aux_sym_deltask_repeat1] = aux_sym_deltask_repeat1,
+  [aux_sym_export_repeat1] = aux_sym_export_repeat1,
+  [aux_sym_include_repeat1] = aux_sym_include_repeat1,
+  [aux_sym_inline_code_repeat1] = aux_sym_inline_code_repeat1,
+  [aux_sym_override_repeat1] = aux_sym_override_repeat1,
   [aux_sym_identifier_repeat1] = aux_sym_identifier_repeat1,
+  [aux_sym_variable_name_repeat1] = aux_sym_variable_name_repeat1,
+  [aux_sym_python_function_repeat1] = aux_sym_python_function_repeat1,
+  [anon_alias_sym_] = anon_alias_sym_,
+  [alias_sym_path] = alias_sym_path,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -280,7 +399,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_statement_token1] = {
+  [aux_sym_code_body_token1] = {
     .visible = false,
     .named = false,
   },
@@ -288,23 +407,19 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_inherit_token1] = {
-    .visible = false,
-    .named = false,
-  },
   [anon_sym_LF] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_require] = {
+  [anon_sym_addtask] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym__require_path_token1] = {
-    .visible = false,
+  [anon_sym_after] = {
+    .visible = true,
     .named = false,
   },
-  [anon_sym_addtask] = {
+  [anon_sym_before] = {
     .visible = true,
     .named = false,
   },
@@ -312,7 +427,39 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [anon_sym_deltask] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_addhandler] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_unset] = {
+    .visible = true,
+    .named = false,
+  },
   [anon_sym_include] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_require] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_include_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym__include_path_fragment_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym__include_path_fragment_token2] = {
+    .visible = false,
+    .named = false,
+  },
+  [anon_sym_EXPORT_FUNCTIONS] = {
     .visible = true,
     .named = false,
   },
@@ -320,15 +467,23 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_string_token1] = {
-    .visible = false,
+  [anon_sym_DQUOTE2] = {
+    .visible = true,
     .named = false,
   },
   [anon_sym_SQUOTE] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_string2_token1] = {
+  [anon_sym_SQUOTE2] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DOLLAR_LBRACE_AT] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym__inline_code_inner_token1] = {
     .visible = false,
     .named = false,
   },
@@ -336,29 +491,61 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_string_expansion_token1] = {
-    .visible = false,
-    .named = false,
+  [sym_string_text_fragment1] = {
+    .visible = true,
+    .named = true,
   },
-  [anon_sym_BSLASH_BSLASH] = {
+  [sym_string_text_fragment2] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_LBRACK] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_string_escape_token1] = {
-    .visible = false,
+  [anon_sym_RBRACK] = {
+    .visible = true,
     .named = false,
+  },
+  [sym_flag_name] = {
+    .visible = true,
+    .named = true,
   },
   [anon_sym_COLON] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_override_token1] = {
+  [anon_sym_append] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_prepend] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_remove] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym__override_fragment_token1] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_identifier_token1] = {
+  [aux_sym_variable_name_token1] = {
     .visible = false,
     .named = false,
+  },
+  [aux_sym__variable_fragment_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [anon_sym_def] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym__python_code] = {
+    .visible = false,
+    .named = true,
   },
   [anon_sym_POUND] = {
     .visible = true,
@@ -380,7 +567,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_task_declaration] = {
+  [sym_shell_task_declaration] = {
     .visible = true,
     .named = true,
   },
@@ -392,7 +579,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_statement] = {
+  [sym_code_body] = {
     .visible = true,
     .named = true,
   },
@@ -400,15 +587,23 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_require] = {
+  [sym_class_name] = {
     .visible = true,
     .named = true,
   },
-  [sym__require_path] = {
-    .visible = false,
+  [sym_function_name] = {
+    .visible = true,
     .named = true,
   },
   [sym_addtask] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_deltask] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_addhandler] = {
     .visible = true,
     .named = true,
   },
@@ -416,7 +611,19 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_unset] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_include] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym__include_path_fragment] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_export_functions] = {
     .visible = true,
     .named = true,
   },
@@ -424,15 +631,35 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_string2] = {
+  [aux_sym__string_inner1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym__string_inner2] = {
+    .visible = false,
+    .named = false,
+  },
+  [sym__expansion] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_python_expansion] = {
     .visible = true,
     .named = true,
   },
-  [sym_string_expansion] = {
+  [sym_inline_code] = {
     .visible = true,
     .named = true,
   },
-  [sym_string_escape] = {
+  [sym__inline_code_inner] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_shell_expansion] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_flag] = {
     .visible = true,
     .named = true,
   },
@@ -440,7 +667,23 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym__override_fragment] = {
+    .visible = false,
+    .named = true,
+  },
   [sym_identifier] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_variable_name] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym__variable_fragment] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_python_function] = {
     .visible = true,
     .named = true,
   },
@@ -452,7 +695,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_block_repeat1] = {
+  [aux_sym_code_body_repeat1] = {
     .visible = false,
     .named = false,
   },
@@ -460,25 +703,49 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym__require_path_repeat1] = {
-    .visible = false,
-    .named = false,
-  },
   [aux_sym_addtask_repeat1] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_string_repeat1] = {
+  [aux_sym_deltask_repeat1] = {
     .visible = false,
     .named = false,
   },
-  [aux_sym_string2_repeat1] = {
+  [aux_sym_export_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_include_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_inline_code_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_override_repeat1] = {
     .visible = false,
     .named = false,
   },
   [aux_sym_identifier_repeat1] = {
     .visible = false,
     .named = false,
+  },
+  [aux_sym_variable_name_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_python_function_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [anon_alias_sym_] = {
+    .visible = true,
+    .named = false,
+  },
+  [alias_sym_path] = {
+    .visible = true,
+    .named = true,
   },
 };
 
@@ -492,98 +759,35 @@ static const char * const ts_field_names[] = {
 };
 
 static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
-  [1] = {.index = 0, .length = 1},
+  [3] = {.index = 0, .length = 1},
+  [4] = {.index = 1, .length = 1},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
   [0] =
     {field_name, 0},
+  [1] =
+    {field_name, 1},
 };
 
 static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
+  [1] = {
+    [0] = anon_alias_sym_,
+  },
+  [2] = {
+    [2] = alias_sym_path,
+  },
 };
 
 static const uint16_t ts_non_terminal_alias_map[] = {
+  sym_variable_name, 2,
+    sym_variable_name,
+    anon_alias_sym_,
+  aux_sym_include_repeat1, 2,
+    aux_sym_include_repeat1,
+    alias_sym_path,
   0,
-};
-
-static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
-  [0] = 0,
-  [1] = 1,
-  [2] = 2,
-  [3] = 3,
-  [4] = 4,
-  [5] = 5,
-  [6] = 6,
-  [7] = 4,
-  [8] = 5,
-  [9] = 6,
-  [10] = 10,
-  [11] = 11,
-  [12] = 10,
-  [13] = 13,
-  [14] = 14,
-  [15] = 15,
-  [16] = 16,
-  [17] = 17,
-  [18] = 18,
-  [19] = 19,
-  [20] = 20,
-  [21] = 21,
-  [22] = 22,
-  [23] = 23,
-  [24] = 24,
-  [25] = 25,
-  [26] = 26,
-  [27] = 27,
-  [28] = 28,
-  [29] = 29,
-  [30] = 30,
-  [31] = 31,
-  [32] = 32,
-  [33] = 33,
-  [34] = 6,
-  [35] = 4,
-  [36] = 5,
-  [37] = 37,
-  [38] = 38,
-  [39] = 39,
-  [40] = 40,
-  [41] = 41,
-  [42] = 42,
-  [43] = 43,
-  [44] = 44,
-  [45] = 45,
-  [46] = 46,
-  [47] = 47,
-  [48] = 48,
-  [49] = 49,
-  [50] = 10,
-  [51] = 51,
-  [52] = 52,
-  [53] = 53,
-  [54] = 54,
-  [55] = 55,
-  [56] = 56,
-  [57] = 57,
-  [58] = 58,
-  [59] = 59,
-  [60] = 60,
-  [61] = 61,
-  [62] = 62,
-  [63] = 63,
-  [64] = 64,
-  [65] = 65,
-  [66] = 66,
-  [67] = 67,
-  [68] = 68,
-  [69] = 69,
-  [70] = 70,
-  [71] = 71,
-  [72] = 72,
-  [73] = 70,
-  [74] = 70,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -591,1032 +795,3118 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(50);
-      if (lookahead == '"') ADVANCE(88);
-      if (lookahead == '#') ADVANCE(138);
-      if (lookahead == '$') ADVANCE(46);
-      if (lookahead == '\'') ADVANCE(93);
-      if (lookahead == '(') ADVANCE(61);
-      if (lookahead == ')') ADVANCE(62);
-      if (lookahead == '+') ADVANCE(9);
-      if (lookahead == '.') ADVANCE(10);
-      if (lookahead == ':') ADVANCE(102);
-      if (lookahead == '=') ADVANCE(53);
-      if (lookahead == '?') ADVANCE(11);
-      if (lookahead == '\\') ADVANCE(13);
-      if (lookahead == 'a') ADVANCE(16);
-      if (lookahead == 'e') ADVANCE(44);
-      if (lookahead == 'i') ADVANCE(28);
-      if (lookahead == 'p') ADVANCE(45);
-      if (lookahead == 'r') ADVANCE(19);
-      if (lookahead == '{') ADVANCE(65);
-      if (lookahead == '}') ADVANCE(66);
+      if (eof) ADVANCE(126);
+      if (lookahead == '"') ADVANCE(185);
+      if (lookahead == '#') ADVANCE(378);
+      if (lookahead == '$') ADVANCE(120);
+      if (lookahead == '\'') ADVANCE(187);
+      if (lookahead == '(') ADVANCE(138);
+      if (lookahead == ')') ADVANCE(139);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == ':') ADVANCE(201);
+      if (lookahead == '=') ADVANCE(130);
+      if (lookahead == '?') ADVANCE(28);
+      if (lookahead == 'E') ADVANCE(43);
+      if (lookahead == '[') ADVANCE(196);
+      if (lookahead == ']') ADVANCE(197);
+      if (lookahead == 'a') ADVANCE(51);
+      if (lookahead == 'b') ADVANCE(57);
+      if (lookahead == 'd') ADVANCE(58);
+      if (lookahead == 'e') ADVANCE(116);
+      if (lookahead == 'i') ADVANCE(83);
+      if (lookahead == 'p') ADVANCE(100);
+      if (lookahead == 'r') ADVANCE(59);
+      if (lookahead == 'u') ADVANCE(84);
+      if (lookahead == '{') ADVANCE(143);
+      if (lookahead == '}') ADVANCE(144);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(0)
+          lookahead == ' ') SKIP(123)
       END_STATE();
     case 1:
-      if (lookahead == '\n') ADVANCE(85);
-      if (lookahead == '+') ADVANCE(9);
-      if (lookahead == '.') ADVANCE(104);
-      if (lookahead == ':') ADVANCE(102);
-      if (lookahead == '=') ADVANCE(53);
-      if (lookahead == '?') ADVANCE(11);
+      if (lookahead == '\n') ADVANCE(161);
+      if (lookahead == '$') ADVANCE(120);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '.') ADVANCE(363);
+      if (lookahead == ':') ADVANCE(201);
+      if (lookahead == '=') ADVANCE(130);
+      if (lookahead == '?') ADVANCE(28);
+      if (lookahead == '[') ADVANCE(196);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(1)
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+          lookahead == ' ') SKIP(6)
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
       END_STATE();
     case 2:
-      if (lookahead == '\n') ADVANCE(85);
-      if (lookahead == ':') ADVANCE(101);
+      if (lookahead == '\n') ADVANCE(161);
+      if (lookahead == '$') ADVANCE(120);
+      if (lookahead == 'a') ADVANCE(367);
+      if (lookahead == 'b') ADVANCE(366);
       if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(2)
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
-      END_STATE();
-    case 3:
-      if (lookahead == '\n') SKIP(3)
-      if (lookahead == '}') ADVANCE(67);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(68);
-      if (lookahead != 0) ADVANCE(69);
-      END_STATE();
-    case 4:
-      if (lookahead == '\n') ADVANCE(76);
-      if (lookahead == ' ') SKIP(4)
-      if (lookahead == '\t' ||
-          lookahead == '\r') ADVANCE(72);
-      if (lookahead != 0) ADVANCE(74);
-      END_STATE();
-    case 5:
-      if (lookahead == '\n') ADVANCE(77);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(5)
-      END_STATE();
-    case 6:
-      if (lookahead == '"') ADVANCE(88);
-      if (lookahead == '$') ADVANCE(92);
-      if (lookahead == '\\') ADVANCE(91);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(90);
-      if (lookahead != 0) ADVANCE(89);
-      END_STATE();
-    case 7:
-      if (lookahead == '"') ADVANCE(100);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(7)
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('c' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 3:
+      if (lookahead == '\n') ADVANCE(161);
+      if (lookahead == '$') ADVANCE(120);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(8)
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 4:
+      if (lookahead == '\n') ADVANCE(161);
+      if (lookahead == '$') ADVANCE(120);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(179);
+      if (lookahead != 0) ADVANCE(180);
+      END_STATE();
+    case 5:
+      if (lookahead == '\n') ADVANCE(161);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '.') ADVANCE(289);
+      if (lookahead == ':') ADVANCE(201);
+      if (lookahead == '=') ADVANCE(130);
+      if (lookahead == '?') ADVANCE(28);
+      if (lookahead == '[') ADVANCE(196);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(6)
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 6:
+      if (lookahead == '\n') ADVANCE(161);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '.') ADVANCE(289);
+      if (lookahead == ':') ADVANCE(27);
+      if (lookahead == '=') ADVANCE(130);
+      if (lookahead == '?') ADVANCE(28);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(6)
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 7:
+      if (lookahead == '\n') ADVANCE(161);
+      if (lookahead == 'a') ADVANCE(324);
+      if (lookahead == 'b') ADVANCE(318);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(7)
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('c' <= lookahead && lookahead <= 'z')) ADVANCE(362);
       END_STATE();
     case 8:
-      if (lookahead == '\'') ADVANCE(93);
+      if (lookahead == '\n') ADVANCE(161);
       if (lookahead == '\t' ||
-          lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(95);
-      if (lookahead != 0) ADVANCE(94);
+          lookahead == ' ') SKIP(8)
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
       END_STATE();
     case 9:
-      if (lookahead == '=') ADVANCE(55);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '#') ADVANCE(379);
+      if (lookahead == 'E') ADVANCE(238);
+      if (lookahead == 'a') ADVANCE(245);
+      if (lookahead == 'd') ADVANCE(248);
+      if (lookahead == 'e') ADVANCE(286);
+      if (lookahead == 'i') ADVANCE(264);
+      if (lookahead == 'p') ADVANCE(287);
+      if (lookahead == 'r') ADVANCE(249);
+      if (lookahead == 'u') ADVANCE(265);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(9);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
     case 10:
-      if (lookahead == '=') ADVANCE(54);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
     case 11:
-      if (lookahead == '=') ADVANCE(57);
-      if (lookahead == '?') ADVANCE(12);
+      if (lookahead == '\n') SKIP(16)
+      if (lookahead == '#') ADVANCE(379);
+      if (lookahead == 'E') ADVANCE(238);
+      if (lookahead == 'a') ADVANCE(245);
+      if (lookahead == 'd') ADVANCE(248);
+      if (lookahead == 'e') ADVANCE(286);
+      if (lookahead == 'i') ADVANCE(264);
+      if (lookahead == 'p') ADVANCE(287);
+      if (lookahead == 'r') ADVANCE(249);
+      if (lookahead == 'u') ADVANCE(265);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(9);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
     case 12:
-      if (lookahead == '=') ADVANCE(58);
+      if (lookahead == '\n') ADVANCE(151);
+      if (lookahead == '$') ADVANCE(120);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(13)
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
       END_STATE();
     case 13:
-      if (lookahead == '\\') ADVANCE(99);
+      if (lookahead == '\n') ADVANCE(151);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(13)
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
       END_STATE();
     case 14:
-      if (lookahead == 'a') ADVANCE(37);
+      if (lookahead == '\n') SKIP(14)
+      if (lookahead == '}') ADVANCE(145);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(146);
+      if (lookahead != 0) ADVANCE(147);
       END_STATE();
     case 15:
-      if (lookahead == 'c') ADVANCE(27);
-      if (lookahead == 'h') ADVANCE(22);
+      if (lookahead == '"') ADVANCE(185);
+      if (lookahead == '$') ADVANCE(119);
+      if (lookahead == '\\') ADVANCE(193);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(192);
       END_STATE();
     case 16:
-      if (lookahead == 'd') ADVANCE(17);
+      if (lookahead == '#') ADVANCE(378);
+      if (lookahead == 'E') ADVANCE(303);
+      if (lookahead == 'a') ADVANCE(310);
+      if (lookahead == 'd') ADVANCE(313);
+      if (lookahead == 'e') ADVANCE(360);
+      if (lookahead == 'i') ADVANCE(334);
+      if (lookahead == 'p') ADVANCE(361);
+      if (lookahead == 'r') ADVANCE(314);
+      if (lookahead == 'u') ADVANCE(335);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(16)
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(362);
       END_STATE();
     case 17:
-      if (lookahead == 'd') ADVANCE(39);
+      if (lookahead == '$') ADVANCE(120);
+      if (lookahead == '(') ADVANCE(138);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '.') ADVANCE(363);
+      if (lookahead == ':') ADVANCE(201);
+      if (lookahead == '=') ADVANCE(130);
+      if (lookahead == '?') ADVANCE(28);
+      if (lookahead == '[') ADVANCE(196);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(22)
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
       END_STATE();
     case 18:
-      if (lookahead == 'd') ADVANCE(20);
+      if (lookahead == '$') ADVANCE(120);
+      if (lookahead == '(') ADVANCE(138);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == ':') ADVANCE(201);
+      if (lookahead == '=') ADVANCE(130);
+      if (lookahead == '?') ADVANCE(28);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(22)
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= '{') ||
+          lookahead == '}') ADVANCE(224);
       END_STATE();
     case 19:
-      if (lookahead == 'e') ADVANCE(33);
+      if (lookahead == '$') ADVANCE(120);
+      if (lookahead == '(') ADVANCE(138);
+      if (lookahead == ':') ADVANCE(200);
+      if (lookahead == '[') ADVANCE(196);
+      if (lookahead == '}') ADVANCE(144);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(23)
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
       END_STATE();
     case 20:
-      if (lookahead == 'e') ADVANCE(86);
+      if (lookahead == '$') ADVANCE(120);
+      if (lookahead == 'a') ADVANCE(219);
+      if (lookahead == 'p') ADVANCE(222);
+      if (lookahead == 'r') ADVANCE(210);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(177);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= '{') ||
+          lookahead == '}') ADVANCE(224);
       END_STATE();
     case 21:
-      if (lookahead == 'e') ADVANCE(78);
+      if (lookahead == '$') ADVANCE(119);
+      if (lookahead == '\'') ADVANCE(187);
+      if (lookahead == '\\') ADVANCE(195);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(194);
       END_STATE();
     case 22:
-      if (lookahead == 'e') ADVANCE(34);
+      if (lookahead == '(') ADVANCE(138);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == ':') ADVANCE(27);
+      if (lookahead == '=') ADVANCE(130);
+      if (lookahead == '?') ADVANCE(28);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(22)
       END_STATE();
     case 23:
-      if (lookahead == 'h') ADVANCE(31);
+      if (lookahead == '(') ADVANCE(138);
+      if (lookahead == '}') ADVANCE(144);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(23)
       END_STATE();
     case 24:
-      if (lookahead == 'i') ADVANCE(36);
+      if (lookahead == '(') ADVANCE(138);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(24)
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
       END_STATE();
     case 25:
-      if (lookahead == 'i') ADVANCE(41);
+      if (lookahead == '=') ADVANCE(132);
       END_STATE();
     case 26:
-      if (lookahead == 'k') ADVANCE(83);
+      if (lookahead == '=') ADVANCE(131);
       END_STATE();
     case 27:
-      if (lookahead == 'l') ADVANCE(43);
+      if (lookahead == '=') ADVANCE(133);
       END_STATE();
     case 28:
-      if (lookahead == 'n') ADVANCE(15);
+      if (lookahead == '=') ADVANCE(134);
+      if (lookahead == '?') ADVANCE(29);
       END_STATE();
     case 29:
-      if (lookahead == 'n') ADVANCE(63);
+      if (lookahead == '=') ADVANCE(135);
       END_STATE();
     case 30:
-      if (lookahead == 'o') ADVANCE(35);
+      if (lookahead == 'C') ADVANCE(41);
       END_STATE();
     case 31:
-      if (lookahead == 'o') ADVANCE(29);
+      if (lookahead == 'F') ADVANCE(42);
       END_STATE();
     case 32:
-      if (lookahead == 'p') ADVANCE(30);
+      if (lookahead == 'I') ADVANCE(36);
       END_STATE();
     case 33:
-      if (lookahead == 'q') ADVANCE(42);
+      if (lookahead == 'N') ADVANCE(30);
       END_STATE();
     case 34:
-      if (lookahead == 'r') ADVANCE(25);
+      if (lookahead == 'N') ADVANCE(39);
       END_STATE();
     case 35:
-      if (lookahead == 'r') ADVANCE(40);
+      if (lookahead == 'O') ADVANCE(38);
       END_STATE();
     case 36:
-      if (lookahead == 'r') ADVANCE(21);
+      if (lookahead == 'O') ADVANCE(34);
       END_STATE();
     case 37:
-      if (lookahead == 's') ADVANCE(26);
+      if (lookahead == 'P') ADVANCE(35);
       END_STATE();
     case 38:
-      if (lookahead == 't') ADVANCE(23);
+      if (lookahead == 'R') ADVANCE(40);
       END_STATE();
     case 39:
-      if (lookahead == 't') ADVANCE(14);
+      if (lookahead == 'S') ADVANCE(181);
       END_STATE();
     case 40:
-      if (lookahead == 't') ADVANCE(51);
+      if (lookahead == 'T') ADVANCE(44);
       END_STATE();
     case 41:
-      if (lookahead == 't') ADVANCE(70);
+      if (lookahead == 'T') ADVANCE(32);
       END_STATE();
     case 42:
-      if (lookahead == 'u') ADVANCE(24);
+      if (lookahead == 'U') ADVANCE(33);
       END_STATE();
     case 43:
-      if (lookahead == 'u') ADVANCE(18);
+      if (lookahead == 'X') ADVANCE(37);
       END_STATE();
     case 44:
-      if (lookahead == 'x') ADVANCE(32);
+      if (lookahead == '_') ADVANCE(31);
       END_STATE();
     case 45:
-      if (lookahead == 'y') ADVANCE(38);
+      if (lookahead == 'a') ADVANCE(324);
+      if (lookahead == 'b') ADVANCE(318);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(45)
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('c' <= lookahead && lookahead <= 'z')) ADVANCE(362);
       END_STATE();
     case 46:
-      if (lookahead == '{') ADVANCE(96);
+      if (lookahead == 'a') ADVANCE(104);
       END_STATE();
     case 47:
-      if (lookahead == '\t' ||
-          lookahead == '\r') ADVANCE(73);
-      if (lookahead == '\n' ||
-          lookahead == ' ') SKIP(47)
-      if (lookahead != 0) ADVANCE(74);
+      if (lookahead == 'a') ADVANCE(105);
       END_STATE();
     case 48:
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(48)
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(103);
+      if (lookahead == 'a') ADVANCE(87);
       END_STATE();
     case 49:
-      if (eof) ADVANCE(50);
-      if (lookahead == '"') ADVANCE(88);
-      if (lookahead == '#') ADVANCE(138);
-      if (lookahead == '\'') ADVANCE(93);
-      if (lookahead == 'a') ADVANCE(107);
-      if (lookahead == 'e') ADVANCE(135);
-      if (lookahead == 'i') ADVANCE(119);
-      if (lookahead == 'p') ADVANCE(136);
-      if (lookahead == 'r') ADVANCE(110);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(49)
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+      if (lookahead == 'c') ADVANCE(80);
+      if (lookahead == 'h') ADVANCE(68);
       END_STATE();
     case 50:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (lookahead == 'd') ADVANCE(52);
+      if (lookahead == 'f') ADVANCE(112);
       END_STATE();
     case 51:
-      ACCEPT_TOKEN(anon_sym_export);
+      if (lookahead == 'd') ADVANCE(52);
+      if (lookahead == 'f') ADVANCE(112);
+      if (lookahead == 'p') ADVANCE(93);
       END_STATE();
     case 52:
-      ACCEPT_TOKEN(anon_sym_export);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+      if (lookahead == 'd') ADVANCE(74);
       END_STATE();
     case 53:
-      ACCEPT_TOKEN(anon_sym_EQ);
-      if (lookahead == '+') ADVANCE(59);
-      if (lookahead == '.') ADVANCE(60);
+      if (lookahead == 'd') ADVANCE(202);
       END_STATE();
     case 54:
-      ACCEPT_TOKEN(anon_sym_DOT_EQ);
+      if (lookahead == 'd') ADVANCE(204);
       END_STATE();
     case 55:
-      ACCEPT_TOKEN(anon_sym_PLUS_EQ);
+      if (lookahead == 'd') ADVANCE(81);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(anon_sym_COLON_EQ);
+      if (lookahead == 'd') ADVANCE(64);
       END_STATE();
     case 57:
-      ACCEPT_TOKEN(anon_sym_QMARK_EQ);
+      if (lookahead == 'e') ADVANCE(72);
       END_STATE();
     case 58:
-      ACCEPT_TOKEN(anon_sym_QMARK_QMARK_EQ);
+      if (lookahead == 'e') ADVANCE(73);
       END_STATE();
     case 59:
-      ACCEPT_TOKEN(anon_sym_EQ_PLUS);
+      if (lookahead == 'e') ADVANCE(82);
       END_STATE();
     case 60:
-      ACCEPT_TOKEN(anon_sym_EQ_DOT);
+      if (lookahead == 'e') ADVANCE(96);
       END_STATE();
     case 61:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
+      if (lookahead == 'e') ADVANCE(97);
       END_STATE();
     case 62:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
+      if (lookahead == 'e') ADVANCE(158);
       END_STATE();
     case 63:
-      ACCEPT_TOKEN(anon_sym_python);
+      if (lookahead == 'e') ADVANCE(206);
       END_STATE();
     case 64:
-      ACCEPT_TOKEN(anon_sym_python);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+      if (lookahead == 'e') ADVANCE(171);
       END_STATE();
     case 65:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+      if (lookahead == 'e') ADVANCE(174);
       END_STATE();
     case 66:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (lookahead == 'e') ADVANCE(86);
       END_STATE();
     case 67:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(69);
+      if (lookahead == 'e') ADVANCE(108);
       END_STATE();
     case 68:
-      ACCEPT_TOKEN(aux_sym_statement_token1);
-      if (lookahead == '}') ADVANCE(67);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(68);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(69);
+      if (lookahead == 'e') ADVANCE(99);
       END_STATE();
     case 69:
-      ACCEPT_TOKEN(aux_sym_statement_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(69);
+      if (lookahead == 'e') ADVANCE(98);
       END_STATE();
     case 70:
-      ACCEPT_TOKEN(anon_sym_inherit);
+      if (lookahead == 'e') ADVANCE(94);
       END_STATE();
     case 71:
-      ACCEPT_TOKEN(anon_sym_inherit);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+      if (lookahead == 'e') ADVANCE(88);
       END_STATE();
     case 72:
-      ACCEPT_TOKEN(aux_sym_inherit_token1);
-      if (lookahead == '\n') ADVANCE(76);
-      if (lookahead == '\t' ||
-          lookahead == '\r') ADVANCE(72);
-      if (lookahead != 0 &&
-          lookahead != ' ') ADVANCE(74);
+      if (lookahead == 'f') ADVANCE(90);
       END_STATE();
     case 73:
-      ACCEPT_TOKEN(aux_sym_inherit_token1);
-      if (lookahead == '\t' ||
-          lookahead == '\r') ADVANCE(73);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(74);
+      if (lookahead == 'f') ADVANCE(374);
+      if (lookahead == 'l') ADVANCE(111);
       END_STATE();
     case 74:
-      ACCEPT_TOKEN(aux_sym_inherit_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != ' ') ADVANCE(74);
+      if (lookahead == 'h') ADVANCE(48);
+      if (lookahead == 't') ADVANCE(46);
       END_STATE();
     case 75:
-      ACCEPT_TOKEN(anon_sym_LF);
-      if (lookahead == '\n') ADVANCE(75);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(80);
+      if (lookahead == 'h') ADVANCE(92);
       END_STATE();
     case 76:
-      ACCEPT_TOKEN(anon_sym_LF);
-      if (lookahead == '\n') ADVANCE(76);
-      if (lookahead == '\t' ||
-          lookahead == '\r') ADVANCE(72);
+      if (lookahead == 'i') ADVANCE(110);
       END_STATE();
     case 77:
-      ACCEPT_TOKEN(anon_sym_LF);
-      if (lookahead == '\n') ADVANCE(77);
+      if (lookahead == 'i') ADVANCE(103);
       END_STATE();
     case 78:
-      ACCEPT_TOKEN(anon_sym_require);
+      if (lookahead == 'k') ADVANCE(152);
       END_STATE();
     case 79:
-      ACCEPT_TOKEN(anon_sym_require);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+      if (lookahead == 'k') ADVANCE(162);
       END_STATE();
     case 80:
-      ACCEPT_TOKEN(aux_sym__require_path_token1);
-      if (lookahead == '\n') ADVANCE(75);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(80);
-      if (lookahead != 0) ADVANCE(82);
+      if (lookahead == 'l') ADVANCE(114);
       END_STATE();
     case 81:
-      ACCEPT_TOKEN(aux_sym__require_path_token1);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(81);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(82);
+      if (lookahead == 'l') ADVANCE(69);
       END_STATE();
     case 82:
-      ACCEPT_TOKEN(aux_sym__require_path_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(82);
+      if (lookahead == 'm') ADVANCE(89);
+      if (lookahead == 'q') ADVANCE(113);
       END_STATE();
     case 83:
-      ACCEPT_TOKEN(anon_sym_addtask);
+      if (lookahead == 'n') ADVANCE(49);
       END_STATE();
     case 84:
-      ACCEPT_TOKEN(anon_sym_addtask);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+      if (lookahead == 'n') ADVANCE(106);
       END_STATE();
     case 85:
-      ACCEPT_TOKEN(aux_sym_addtask_token1);
-      if (lookahead == '\n') ADVANCE(85);
+      if (lookahead == 'n') ADVANCE(140);
       END_STATE();
     case 86:
-      ACCEPT_TOKEN(anon_sym_include);
+      if (lookahead == 'n') ADVANCE(53);
       END_STATE();
     case 87:
-      ACCEPT_TOKEN(anon_sym_include);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+      if (lookahead == 'n') ADVANCE(55);
       END_STATE();
     case 88:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      if (lookahead == 'n') ADVANCE(54);
       END_STATE();
     case 89:
-      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == 'o') ADVANCE(115);
       END_STATE();
     case 90:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '$') ADVANCE(92);
-      if (lookahead == '\\') ADVANCE(91);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(90);
-      if (lookahead != 0 &&
-          lookahead != '"') ADVANCE(89);
+      if (lookahead == 'o') ADVANCE(102);
       END_STATE();
     case 91:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '\\') ADVANCE(99);
+      if (lookahead == 'o') ADVANCE(101);
       END_STATE();
     case 92:
-      ACCEPT_TOKEN(aux_sym_string_token1);
-      if (lookahead == '{') ADVANCE(96);
+      if (lookahead == 'o') ADVANCE(85);
       END_STATE();
     case 93:
-      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      if (lookahead == 'p') ADVANCE(66);
       END_STATE();
     case 94:
-      ACCEPT_TOKEN(aux_sym_string2_token1);
+      if (lookahead == 'p') ADVANCE(71);
       END_STATE();
     case 95:
-      ACCEPT_TOKEN(aux_sym_string2_token1);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(95);
-      if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(94);
+      if (lookahead == 'p') ADVANCE(91);
       END_STATE();
     case 96:
-      ACCEPT_TOKEN(anon_sym_DOLLAR_LBRACE);
+      if (lookahead == 'q') ADVANCE(113);
       END_STATE();
     case 97:
-      ACCEPT_TOKEN(aux_sym_string_expansion_token1);
+      if (lookahead == 'r') ADVANCE(155);
+      END_STATE();
+    case 98:
+      if (lookahead == 'r') ADVANCE(165);
+      END_STATE();
+    case 99:
+      if (lookahead == 'r') ADVANCE(76);
+      END_STATE();
+    case 100:
+      if (lookahead == 'r') ADVANCE(70);
+      if (lookahead == 'y') ADVANCE(107);
+      END_STATE();
+    case 101:
+      if (lookahead == 'r') ADVANCE(109);
+      END_STATE();
+    case 102:
+      if (lookahead == 'r') ADVANCE(62);
+      END_STATE();
+    case 103:
+      if (lookahead == 'r') ADVANCE(65);
+      END_STATE();
+    case 104:
+      if (lookahead == 's') ADVANCE(78);
+      END_STATE();
+    case 105:
+      if (lookahead == 's') ADVANCE(79);
+      END_STATE();
+    case 106:
+      if (lookahead == 's') ADVANCE(67);
+      END_STATE();
+    case 107:
+      if (lookahead == 't') ADVANCE(75);
+      END_STATE();
+    case 108:
+      if (lookahead == 't') ADVANCE(168);
+      END_STATE();
+    case 109:
+      if (lookahead == 't') ADVANCE(127);
+      END_STATE();
+    case 110:
+      if (lookahead == 't') ADVANCE(148);
+      END_STATE();
+    case 111:
+      if (lookahead == 't') ADVANCE(47);
+      END_STATE();
+    case 112:
+      if (lookahead == 't') ADVANCE(61);
+      END_STATE();
+    case 113:
+      if (lookahead == 'u') ADVANCE(77);
+      END_STATE();
+    case 114:
+      if (lookahead == 'u') ADVANCE(56);
+      END_STATE();
+    case 115:
+      if (lookahead == 'v') ADVANCE(63);
+      END_STATE();
+    case 116:
+      if (lookahead == 'x') ADVANCE(95);
+      END_STATE();
+    case 117:
+      if (lookahead == 'y') ADVANCE(107);
+      END_STATE();
+    case 118:
+      if (lookahead == '{') ADVANCE(143);
+      if (lookahead == '}') ADVANCE(144);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(97);
+          lookahead == ' ') ADVANCE(189);
+      if (lookahead != 0) ADVANCE(190);
+      END_STATE();
+    case 119:
+      if (lookahead == '{') ADVANCE(191);
+      END_STATE();
+    case 120:
+      if (lookahead == '{') ADVANCE(191);
+      if (lookahead != 0) ADVANCE(178);
+      END_STATE();
+    case 121:
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(198);
       if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(98);
+          lookahead != ']') ADVANCE(199);
       END_STATE();
-    case 98:
-      ACCEPT_TOKEN(aux_sym_string_expansion_token1);
+    case 122:
+      if (eof) ADVANCE(126);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '\r') SKIP(125)
+      if (lookahead == '#') ADVANCE(378);
+      if (lookahead == 'E') ADVANCE(303);
+      if (lookahead == 'a') ADVANCE(310);
+      if (lookahead == 'd') ADVANCE(313);
+      if (lookahead == 'e') ADVANCE(360);
+      if (lookahead == 'i') ADVANCE(334);
+      if (lookahead == 'p') ADVANCE(361);
+      if (lookahead == 'r') ADVANCE(314);
+      if (lookahead == 'u') ADVANCE(335);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(11);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 123:
+      if (eof) ADVANCE(126);
+      if (lookahead == '"') ADVANCE(184);
+      if (lookahead == '#') ADVANCE(378);
+      if (lookahead == '\'') ADVANCE(186);
+      if (lookahead == '(') ADVANCE(138);
+      if (lookahead == ')') ADVANCE(139);
+      if (lookahead == '+') ADVANCE(25);
+      if (lookahead == '.') ADVANCE(26);
+      if (lookahead == ':') ADVANCE(27);
+      if (lookahead == '=') ADVANCE(130);
+      if (lookahead == '?') ADVANCE(28);
+      if (lookahead == 'E') ADVANCE(43);
+      if (lookahead == ']') ADVANCE(197);
+      if (lookahead == 'a') ADVANCE(50);
+      if (lookahead == 'b') ADVANCE(57);
+      if (lookahead == 'd') ADVANCE(58);
+      if (lookahead == 'e') ADVANCE(116);
+      if (lookahead == 'i') ADVANCE(83);
+      if (lookahead == 'p') ADVANCE(117);
+      if (lookahead == 'r') ADVANCE(60);
+      if (lookahead == 'u') ADVANCE(84);
+      if (lookahead == '{') ADVANCE(143);
+      if (lookahead == '}') ADVANCE(144);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(123)
+      END_STATE();
+    case 124:
+      if (eof) ADVANCE(126);
+      if (lookahead == '"') ADVANCE(184);
+      if (lookahead == '#') ADVANCE(378);
+      if (lookahead == '\'') ADVANCE(186);
+      if (lookahead == 'E') ADVANCE(303);
+      if (lookahead == 'a') ADVANCE(310);
+      if (lookahead == 'd') ADVANCE(313);
+      if (lookahead == 'e') ADVANCE(360);
+      if (lookahead == 'i') ADVANCE(334);
+      if (lookahead == 'p') ADVANCE(361);
+      if (lookahead == 'r') ADVANCE(314);
+      if (lookahead == 'u') ADVANCE(335);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(124)
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 125:
+      if (eof) ADVANCE(126);
+      if (lookahead == '#') ADVANCE(378);
+      if (lookahead == 'E') ADVANCE(303);
+      if (lookahead == 'a') ADVANCE(310);
+      if (lookahead == 'd') ADVANCE(313);
+      if (lookahead == 'e') ADVANCE(360);
+      if (lookahead == 'i') ADVANCE(334);
+      if (lookahead == 'p') ADVANCE(361);
+      if (lookahead == 'r') ADVANCE(314);
+      if (lookahead == 'u') ADVANCE(335);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(125)
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 126:
+      ACCEPT_TOKEN(ts_builtin_sym_end);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(anon_sym_export);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(anon_sym_export);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 129:
+      ACCEPT_TOKEN(anon_sym_export);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 130:
+      ACCEPT_TOKEN(anon_sym_EQ);
+      if (lookahead == '+') ADVANCE(136);
+      if (lookahead == '.') ADVANCE(137);
+      END_STATE();
+    case 131:
+      ACCEPT_TOKEN(anon_sym_DOT_EQ);
+      END_STATE();
+    case 132:
+      ACCEPT_TOKEN(anon_sym_PLUS_EQ);
+      END_STATE();
+    case 133:
+      ACCEPT_TOKEN(anon_sym_COLON_EQ);
+      END_STATE();
+    case 134:
+      ACCEPT_TOKEN(anon_sym_QMARK_EQ);
+      END_STATE();
+    case 135:
+      ACCEPT_TOKEN(anon_sym_QMARK_QMARK_EQ);
+      END_STATE();
+    case 136:
+      ACCEPT_TOKEN(anon_sym_EQ_PLUS);
+      END_STATE();
+    case 137:
+      ACCEPT_TOKEN(anon_sym_EQ_DOT);
+      END_STATE();
+    case 138:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      END_STATE();
+    case 139:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      END_STATE();
+    case 140:
+      ACCEPT_TOKEN(anon_sym_python);
+      END_STATE();
+    case 141:
+      ACCEPT_TOKEN(anon_sym_python);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 142:
+      ACCEPT_TOKEN(anon_sym_python);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 143:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      END_STATE();
+    case 144:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 145:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
       if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(98);
+          lookahead != '\n') ADVANCE(147);
       END_STATE();
-    case 99:
-      ACCEPT_TOKEN(anon_sym_BSLASH_BSLASH);
+    case 146:
+      ACCEPT_TOKEN(aux_sym_code_body_token1);
+      if (lookahead == '}') ADVANCE(145);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(146);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(147);
       END_STATE();
-    case 100:
-      ACCEPT_TOKEN(aux_sym_string_escape_token1);
+    case 147:
+      ACCEPT_TOKEN(aux_sym_code_body_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(147);
       END_STATE();
-    case 101:
+    case 148:
+      ACCEPT_TOKEN(anon_sym_inherit);
+      END_STATE();
+    case 149:
+      ACCEPT_TOKEN(anon_sym_inherit);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 150:
+      ACCEPT_TOKEN(anon_sym_inherit);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 151:
+      ACCEPT_TOKEN(anon_sym_LF);
+      if (lookahead == '\n') ADVANCE(151);
+      END_STATE();
+    case 152:
+      ACCEPT_TOKEN(anon_sym_addtask);
+      END_STATE();
+    case 153:
+      ACCEPT_TOKEN(anon_sym_addtask);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 154:
+      ACCEPT_TOKEN(anon_sym_addtask);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 155:
+      ACCEPT_TOKEN(anon_sym_after);
+      END_STATE();
+    case 156:
+      ACCEPT_TOKEN(anon_sym_after);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 157:
+      ACCEPT_TOKEN(anon_sym_after);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 158:
+      ACCEPT_TOKEN(anon_sym_before);
+      END_STATE();
+    case 159:
+      ACCEPT_TOKEN(anon_sym_before);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 160:
+      ACCEPT_TOKEN(anon_sym_before);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 161:
+      ACCEPT_TOKEN(aux_sym_addtask_token1);
+      if (lookahead == '\n') ADVANCE(161);
+      END_STATE();
+    case 162:
+      ACCEPT_TOKEN(anon_sym_deltask);
+      END_STATE();
+    case 163:
+      ACCEPT_TOKEN(anon_sym_deltask);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 164:
+      ACCEPT_TOKEN(anon_sym_deltask);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 165:
+      ACCEPT_TOKEN(anon_sym_addhandler);
+      END_STATE();
+    case 166:
+      ACCEPT_TOKEN(anon_sym_addhandler);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 167:
+      ACCEPT_TOKEN(anon_sym_addhandler);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 168:
+      ACCEPT_TOKEN(anon_sym_unset);
+      END_STATE();
+    case 169:
+      ACCEPT_TOKEN(anon_sym_unset);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 170:
+      ACCEPT_TOKEN(anon_sym_unset);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 171:
+      ACCEPT_TOKEN(anon_sym_include);
+      END_STATE();
+    case 172:
+      ACCEPT_TOKEN(anon_sym_include);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 173:
+      ACCEPT_TOKEN(anon_sym_include);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 174:
+      ACCEPT_TOKEN(anon_sym_require);
+      END_STATE();
+    case 175:
+      ACCEPT_TOKEN(anon_sym_require);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 176:
+      ACCEPT_TOKEN(anon_sym_require);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 177:
+      ACCEPT_TOKEN(aux_sym_include_token1);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(177);
+      END_STATE();
+    case 178:
+      ACCEPT_TOKEN(aux_sym__include_path_fragment_token1);
+      END_STATE();
+    case 179:
+      ACCEPT_TOKEN(aux_sym__include_path_fragment_token2);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(179);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '$') ADVANCE(180);
+      END_STATE();
+    case 180:
+      ACCEPT_TOKEN(aux_sym__include_path_fragment_token2);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '$') ADVANCE(180);
+      END_STATE();
+    case 181:
+      ACCEPT_TOKEN(anon_sym_EXPORT_FUNCTIONS);
+      END_STATE();
+    case 182:
+      ACCEPT_TOKEN(anon_sym_EXPORT_FUNCTIONS);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 183:
+      ACCEPT_TOKEN(anon_sym_EXPORT_FUNCTIONS);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 184:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 185:
+      ACCEPT_TOKEN(anon_sym_DQUOTE2);
+      END_STATE();
+    case 186:
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      END_STATE();
+    case 187:
+      ACCEPT_TOKEN(anon_sym_SQUOTE2);
+      END_STATE();
+    case 188:
+      ACCEPT_TOKEN(anon_sym_DOLLAR_LBRACE_AT);
+      END_STATE();
+    case 189:
+      ACCEPT_TOKEN(aux_sym__inline_code_inner_token1);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(189);
+      if (lookahead != 0 &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(190);
+      END_STATE();
+    case 190:
+      ACCEPT_TOKEN(aux_sym__inline_code_inner_token1);
+      if (lookahead != 0 &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(190);
+      END_STATE();
+    case 191:
+      ACCEPT_TOKEN(anon_sym_DOLLAR_LBRACE);
+      if (lookahead == '@') ADVANCE(188);
+      END_STATE();
+    case 192:
+      ACCEPT_TOKEN(sym_string_text_fragment1);
+      if (lookahead == '\\') ADVANCE(193);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '"' &&
+          lookahead != '$') ADVANCE(192);
+      END_STATE();
+    case 193:
+      ACCEPT_TOKEN(sym_string_text_fragment1);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '$' &&
+          lookahead != '\\') ADVANCE(192);
+      if (lookahead == '\\') ADVANCE(193);
+      END_STATE();
+    case 194:
+      ACCEPT_TOKEN(sym_string_text_fragment2);
+      if (lookahead == '\\') ADVANCE(195);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '$' &&
+          lookahead != '\'') ADVANCE(194);
+      END_STATE();
+    case 195:
+      ACCEPT_TOKEN(sym_string_text_fragment2);
+      if (lookahead != 0 &&
+          lookahead != '$' &&
+          lookahead != '\'' &&
+          lookahead != '\\') ADVANCE(194);
+      if (lookahead == '\\') ADVANCE(195);
+      END_STATE();
+    case 196:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      END_STATE();
+    case 197:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      END_STATE();
+    case 198:
+      ACCEPT_TOKEN(sym_flag_name);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(198);
+      if (lookahead != 0 &&
+          lookahead != ']') ADVANCE(199);
+      END_STATE();
+    case 199:
+      ACCEPT_TOKEN(sym_flag_name);
+      if (lookahead != 0 &&
+          lookahead != ']') ADVANCE(199);
+      END_STATE();
+    case 200:
       ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
-    case 102:
+    case 201:
       ACCEPT_TOKEN(anon_sym_COLON);
-      if (lookahead == '=') ADVANCE(56);
+      if (lookahead == '=') ADVANCE(133);
       END_STATE();
-    case 103:
-      ACCEPT_TOKEN(aux_sym_override_token1);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 202:
+      ACCEPT_TOKEN(anon_sym_append);
+      END_STATE();
+    case 203:
+      ACCEPT_TOKEN(anon_sym_append);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(103);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 104:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '=') ADVANCE(54);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 204:
+      ACCEPT_TOKEN(anon_sym_prepend);
+      END_STATE();
+    case 205:
+      ACCEPT_TOKEN(anon_sym_prepend);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 105:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'a') ADVANCE(128);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+    case 206:
+      ACCEPT_TOKEN(anon_sym_remove);
       END_STATE();
-    case 106:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'c') ADVANCE(118);
-      if (lookahead == 'h') ADVANCE(113);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 207:
+      ACCEPT_TOKEN(anon_sym_remove);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 107:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'd') ADVANCE(108);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 208:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'd') ADVANCE(203);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 108:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'd') ADVANCE(130);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 209:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'd') ADVANCE(205);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 109:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'd') ADVANCE(111);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 210:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'e') ADVANCE(215);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 110:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(124);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 211:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'e') ADVANCE(216);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 111:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(87);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 212:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'e') ADVANCE(207);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 112:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(79);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 213:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'e') ADVANCE(217);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 113:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'e') ADVANCE(125);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 214:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'e') ADVANCE(221);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 114:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'h') ADVANCE(122);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 215:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'm') ADVANCE(218);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 115:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'i') ADVANCE(127);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 216:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'n') ADVANCE(208);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 116:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'i') ADVANCE(132);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 217:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'n') ADVANCE(209);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 117:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'k') ADVANCE(84);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 218:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'o') ADVANCE(223);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 118:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'l') ADVANCE(134);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 219:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'p') ADVANCE(220);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 119:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'n') ADVANCE(106);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 220:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'p') ADVANCE(211);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 120:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'n') ADVANCE(64);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 221:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'p') ADVANCE(213);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 121:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'o') ADVANCE(126);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 222:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'r') ADVANCE(214);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 122:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'o') ADVANCE(120);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 223:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == 'v') ADVANCE(212);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 123:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'p') ADVANCE(121);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
-          lookahead == '.' ||
+    case 224:
+      ACCEPT_TOKEN(aux_sym__override_fragment_token1);
+      if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          lookahead == '}') ADVANCE(224);
       END_STATE();
-    case 124:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'q') ADVANCE(133);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 225:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'C') ADVANCE(236);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 125:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'r') ADVANCE(116);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 226:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'F') ADVANCE(237);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 126:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'r') ADVANCE(131);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 227:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'I') ADVANCE(231);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 127:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'r') ADVANCE(112);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 228:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'N') ADVANCE(225);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 128:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 's') ADVANCE(117);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 229:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'N') ADVANCE(234);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 129:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 't') ADVANCE(114);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 230:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'O') ADVANCE(233);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 130:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 't') ADVANCE(105);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 231:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'O') ADVANCE(229);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 131:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 't') ADVANCE(52);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 232:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'P') ADVANCE(230);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 132:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 't') ADVANCE(71);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 233:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'R') ADVANCE(235);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 133:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'u') ADVANCE(115);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 234:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'S') ADVANCE(182);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 134:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'u') ADVANCE(109);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 235:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'T') ADVANCE(239);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 135:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'x') ADVANCE(123);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 236:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'T') ADVANCE(227);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 136:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == 'y') ADVANCE(129);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 237:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'U') ADVANCE(228);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 137:
-      ACCEPT_TOKEN(aux_sym_identifier_token1);
-      if (lookahead == '$' ||
-          lookahead == '-' ||
+    case 238:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'X') ADVANCE(232);
+      if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('@' <= lookahead && lookahead <= '[') ||
-          lookahead == ']' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= '{') ||
-          lookahead == '}') ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
       END_STATE();
-    case 138:
+    case 239:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '_') ADVANCE(226);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 240:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'a') ADVANCE(276);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 241:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'a') ADVANCE(267);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 242:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'a') ADVANCE(277);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 243:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'c') ADVANCE(262);
+      if (lookahead == 'h') ADVANCE(252);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 244:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'd') ADVANCE(256);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 245:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'd') ADVANCE(244);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 246:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'd') ADVANCE(263);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 247:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'd') ADVANCE(250);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 248:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'e') ADVANCE(255);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 249:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'e') ADVANCE(271);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 250:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'e') ADVANCE(172);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 251:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'e') ADVANCE(175);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 252:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'e') ADVANCE(273);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 253:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'e') ADVANCE(280);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 254:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'e') ADVANCE(272);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 255:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'f') ADVANCE(375);
+      if (lookahead == 'l') ADVANCE(283);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 256:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'h') ADVANCE(241);
+      if (lookahead == 't') ADVANCE(240);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 257:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'h') ADVANCE(269);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 258:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'i') ADVANCE(275);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 259:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'i') ADVANCE(282);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 260:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'k') ADVANCE(153);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 261:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'k') ADVANCE(163);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 262:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'l') ADVANCE(285);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 263:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'l') ADVANCE(254);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 264:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'n') ADVANCE(243);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 265:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'n') ADVANCE(278);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 266:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'n') ADVANCE(141);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 267:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'n') ADVANCE(246);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 268:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'o') ADVANCE(274);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 269:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'o') ADVANCE(266);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 270:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'p') ADVANCE(268);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 271:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'q') ADVANCE(284);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 272:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'r') ADVANCE(166);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 273:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'r') ADVANCE(259);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 274:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'r') ADVANCE(281);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 275:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'r') ADVANCE(251);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 276:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 's') ADVANCE(260);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 277:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 's') ADVANCE(261);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 278:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 's') ADVANCE(253);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 279:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 't') ADVANCE(257);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 280:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 't') ADVANCE(169);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 281:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 't') ADVANCE(128);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 282:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 't') ADVANCE(149);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 283:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 't') ADVANCE(242);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 284:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'u') ADVANCE(258);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 285:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'u') ADVANCE(247);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 286:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'x') ADVANCE(270);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 287:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == 'y') ADVANCE(279);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 288:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 289:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '=') ADVANCE(131);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 290:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'C') ADVANCE(301);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 291:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'F') ADVANCE(302);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 292:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'I') ADVANCE(296);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 293:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'N') ADVANCE(290);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 294:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'N') ADVANCE(299);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 295:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'O') ADVANCE(298);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 296:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'O') ADVANCE(294);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 297:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'P') ADVANCE(295);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 298:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'R') ADVANCE(300);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 299:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'S') ADVANCE(183);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 300:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'T') ADVANCE(304);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 301:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'T') ADVANCE(292);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 302:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'U') ADVANCE(293);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 303:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'X') ADVANCE(297);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 304:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '_') ADVANCE(291);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 305:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'a') ADVANCE(349);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 306:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'a') ADVANCE(337);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 307:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'a') ADVANCE(350);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 308:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'c') ADVANCE(332);
+      if (lookahead == 'h') ADVANCE(317);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 309:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'd') ADVANCE(326);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 310:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'd') ADVANCE(309);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 311:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'd') ADVANCE(333);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 312:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'd') ADVANCE(315);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 313:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'e') ADVANCE(323);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 314:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'e') ADVANCE(342);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 315:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'e') ADVANCE(173);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 316:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'e') ADVANCE(176);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 317:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'e') ADVANCE(344);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 318:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'e') ADVANCE(325);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 319:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'e') ADVANCE(159);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 320:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'e') ADVANCE(353);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 321:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'e') ADVANCE(343);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 322:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'e') ADVANCE(345);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 323:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'f') ADVANCE(376);
+      if (lookahead == 'l') ADVANCE(356);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 324:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'f') ADVANCE(357);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 325:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'f') ADVANCE(340);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 326:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'h') ADVANCE(306);
+      if (lookahead == 't') ADVANCE(305);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 327:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'h') ADVANCE(339);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 328:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'i') ADVANCE(347);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 329:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'i') ADVANCE(355);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 330:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'k') ADVANCE(154);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 331:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'k') ADVANCE(164);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 332:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'l') ADVANCE(359);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 333:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'l') ADVANCE(321);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 334:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'n') ADVANCE(308);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 335:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'n') ADVANCE(351);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 336:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'n') ADVANCE(142);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 337:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'n') ADVANCE(311);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 338:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'o') ADVANCE(346);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 339:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'o') ADVANCE(336);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 340:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'o') ADVANCE(348);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 341:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'p') ADVANCE(338);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 342:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'q') ADVANCE(358);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 343:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'r') ADVANCE(167);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 344:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'r') ADVANCE(329);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 345:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'r') ADVANCE(156);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 346:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'r') ADVANCE(354);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 347:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'r') ADVANCE(316);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 348:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'r') ADVANCE(319);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 349:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 's') ADVANCE(330);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 350:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 's') ADVANCE(331);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 351:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 's') ADVANCE(320);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 352:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 't') ADVANCE(327);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 353:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 't') ADVANCE(170);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 354:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 't') ADVANCE(129);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 355:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 't') ADVANCE(150);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 356:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 't') ADVANCE(307);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 357:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 't') ADVANCE(322);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 358:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'u') ADVANCE(328);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 359:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'u') ADVANCE(312);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 360:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'x') ADVANCE(341);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 361:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == 'y') ADVANCE(352);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 362:
+      ACCEPT_TOKEN(aux_sym_variable_name_token1);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 363:
+      ACCEPT_TOKEN(aux_sym__variable_fragment_token1);
+      if (lookahead == '=') ADVANCE(131);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 364:
+      ACCEPT_TOKEN(aux_sym__variable_fragment_token1);
+      if (lookahead == 'e') ADVANCE(370);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 365:
+      ACCEPT_TOKEN(aux_sym__variable_fragment_token1);
+      if (lookahead == 'e') ADVANCE(160);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 366:
+      ACCEPT_TOKEN(aux_sym__variable_fragment_token1);
+      if (lookahead == 'e') ADVANCE(368);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 367:
+      ACCEPT_TOKEN(aux_sym__variable_fragment_token1);
+      if (lookahead == 'f') ADVANCE(372);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 368:
+      ACCEPT_TOKEN(aux_sym__variable_fragment_token1);
+      if (lookahead == 'f') ADVANCE(369);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 369:
+      ACCEPT_TOKEN(aux_sym__variable_fragment_token1);
+      if (lookahead == 'o') ADVANCE(371);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 370:
+      ACCEPT_TOKEN(aux_sym__variable_fragment_token1);
+      if (lookahead == 'r') ADVANCE(157);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 371:
+      ACCEPT_TOKEN(aux_sym__variable_fragment_token1);
+      if (lookahead == 'r') ADVANCE(365);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 372:
+      ACCEPT_TOKEN(aux_sym__variable_fragment_token1);
+      if (lookahead == 't') ADVANCE(364);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 373:
+      ACCEPT_TOKEN(aux_sym__variable_fragment_token1);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(373);
+      END_STATE();
+    case 374:
+      ACCEPT_TOKEN(anon_sym_def);
+      END_STATE();
+    case 375:
+      ACCEPT_TOKEN(anon_sym_def);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(288);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 376:
+      ACCEPT_TOKEN(anon_sym_def);
+      if (lookahead == '-' ||
+          lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(362);
+      END_STATE();
+    case 377:
+      ACCEPT_TOKEN(sym__python_code);
+      END_STATE();
+    case 378:
       ACCEPT_TOKEN(anon_sym_POUND);
       END_STATE();
-    case 139:
+    case 379:
+      ACCEPT_TOKEN(anon_sym_POUND);
+      if (lookahead == '\n') ADVANCE(377);
+      if (lookahead != 0) ADVANCE(10);
+      END_STATE();
+    case 380:
       ACCEPT_TOKEN(aux_sym_comment_token1);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(139);
+          lookahead == ' ') ADVANCE(380);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(140);
+          lookahead != '\n') ADVANCE(381);
       END_STATE();
-    case 140:
+    case 381:
       ACCEPT_TOKEN(aux_sym_comment_token1);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(140);
+          lookahead != '\n') ADVANCE(381);
       END_STATE();
     default:
       return false;
@@ -1625,80 +3915,180 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 49},
-  [2] = {.lex_state = 49},
-  [3] = {.lex_state = 49},
+  [1] = {.lex_state = 124},
+  [2] = {.lex_state = 124},
+  [3] = {.lex_state = 124},
   [4] = {.lex_state = 1},
   [5] = {.lex_state = 1},
   [6] = {.lex_state = 1},
-  [7] = {.lex_state = 0},
-  [8] = {.lex_state = 0},
-  [9] = {.lex_state = 0},
-  [10] = {.lex_state = 1},
-  [11] = {.lex_state = 1},
-  [12] = {.lex_state = 0},
-  [13] = {.lex_state = 49},
-  [14] = {.lex_state = 49},
-  [15] = {.lex_state = 49},
-  [16] = {.lex_state = 49},
-  [17] = {.lex_state = 49},
-  [18] = {.lex_state = 49},
-  [19] = {.lex_state = 49},
-  [20] = {.lex_state = 49},
-  [21] = {.lex_state = 0},
-  [22] = {.lex_state = 49},
-  [23] = {.lex_state = 49},
-  [24] = {.lex_state = 49},
-  [25] = {.lex_state = 49},
-  [26] = {.lex_state = 49},
-  [27] = {.lex_state = 49},
-  [28] = {.lex_state = 49},
-  [29] = {.lex_state = 49},
-  [30] = {.lex_state = 49},
-  [31] = {.lex_state = 6},
-  [32] = {.lex_state = 6},
-  [33] = {.lex_state = 6},
-  [34] = {.lex_state = 2},
-  [35] = {.lex_state = 2},
-  [36] = {.lex_state = 2},
-  [37] = {.lex_state = 6},
-  [38] = {.lex_state = 49},
-  [39] = {.lex_state = 6},
-  [40] = {.lex_state = 3},
+  [7] = {.lex_state = 17},
+  [8] = {.lex_state = 17},
+  [9] = {.lex_state = 17},
+  [10] = {.lex_state = 18},
+  [11] = {.lex_state = 18},
+  [12] = {.lex_state = 122},
+  [13] = {.lex_state = 122},
+  [14] = {.lex_state = 122},
+  [15] = {.lex_state = 1},
+  [16] = {.lex_state = 1},
+  [17] = {.lex_state = 17},
+  [18] = {.lex_state = 17},
+  [19] = {.lex_state = 5},
+  [20] = {.lex_state = 124},
+  [21] = {.lex_state = 124},
+  [22] = {.lex_state = 124},
+  [23] = {.lex_state = 18},
+  [24] = {.lex_state = 0},
+  [25] = {.lex_state = 124},
+  [26] = {.lex_state = 124},
+  [27] = {.lex_state = 124},
+  [28] = {.lex_state = 124},
+  [29] = {.lex_state = 124},
+  [30] = {.lex_state = 124},
+  [31] = {.lex_state = 124},
+  [32] = {.lex_state = 18},
+  [33] = {.lex_state = 124},
+  [34] = {.lex_state = 124},
+  [35] = {.lex_state = 124},
+  [36] = {.lex_state = 124},
+  [37] = {.lex_state = 124},
+  [38] = {.lex_state = 124},
+  [39] = {.lex_state = 124},
+  [40] = {.lex_state = 124},
   [41] = {.lex_state = 2},
   [42] = {.lex_state = 2},
-  [43] = {.lex_state = 3},
-  [44] = {.lex_state = 49},
-  [45] = {.lex_state = 3},
-  [46] = {.lex_state = 2},
-  [47] = {.lex_state = 8},
-  [48] = {.lex_state = 81},
-  [49] = {.lex_state = 80},
-  [50] = {.lex_state = 2},
-  [51] = {.lex_state = 7},
-  [52] = {.lex_state = 7},
-  [53] = {.lex_state = 80},
-  [54] = {.lex_state = 7},
-  [55] = {.lex_state = 4},
-  [56] = {.lex_state = 8},
+  [43] = {.lex_state = 19},
+  [44] = {.lex_state = 19},
+  [45] = {.lex_state = 2},
+  [46] = {.lex_state = 19},
+  [47] = {.lex_state = 0},
+  [48] = {.lex_state = 20},
+  [49] = {.lex_state = 0},
+  [50] = {.lex_state = 3},
+  [51] = {.lex_state = 3},
+  [52] = {.lex_state = 12},
+  [53] = {.lex_state = 12},
+  [54] = {.lex_state = 12},
+  [55] = {.lex_state = 3},
+  [56] = {.lex_state = 0},
   [57] = {.lex_state = 4},
-  [58] = {.lex_state = 8},
-  [59] = {.lex_state = 47},
+  [58] = {.lex_state = 4},
+  [59] = {.lex_state = 4},
   [60] = {.lex_state = 0},
-  [61] = {.lex_state = 3},
-  [62] = {.lex_state = 5},
-  [63] = {.lex_state = 0},
-  [64] = {.lex_state = 0},
-  [65] = {.lex_state = 0},
-  [66] = {.lex_state = 139},
-  [67] = {.lex_state = 47},
-  [68] = {.lex_state = 0},
-  [69] = {.lex_state = 1},
-  [70] = {.lex_state = 48},
-  [71] = {.lex_state = 7},
-  [72] = {.lex_state = 97},
-  [73] = {.lex_state = 48},
-  [74] = {.lex_state = 48},
+  [61] = {.lex_state = 0},
+  [62] = {.lex_state = 0},
+  [63] = {.lex_state = 15},
+  [64] = {.lex_state = 15},
+  [65] = {.lex_state = 21},
+  [66] = {.lex_state = 21},
+  [67] = {.lex_state = 15},
+  [68] = {.lex_state = 2},
+  [69] = {.lex_state = 19},
+  [70] = {.lex_state = 19},
+  [71] = {.lex_state = 2},
+  [72] = {.lex_state = 0},
+  [73] = {.lex_state = 21},
+  [74] = {.lex_state = 7},
+  [75] = {.lex_state = 7},
+  [76] = {.lex_state = 12},
+  [77] = {.lex_state = 45},
+  [78] = {.lex_state = 3},
+  [79] = {.lex_state = 3},
+  [80] = {.lex_state = 12},
+  [81] = {.lex_state = 118},
+  [82] = {.lex_state = 13},
+  [83] = {.lex_state = 118},
+  [84] = {.lex_state = 118},
+  [85] = {.lex_state = 118},
+  [86] = {.lex_state = 118},
+  [87] = {.lex_state = 118},
+  [88] = {.lex_state = 4},
+  [89] = {.lex_state = 13},
+  [90] = {.lex_state = 118},
+  [91] = {.lex_state = 118},
+  [92] = {.lex_state = 118},
+  [93] = {.lex_state = 8},
+  [94] = {.lex_state = 8},
+  [95] = {.lex_state = 4},
+  [96] = {.lex_state = 4},
+  [97] = {.lex_state = 118},
+  [98] = {.lex_state = 118},
+  [99] = {.lex_state = 8},
+  [100] = {.lex_state = 8},
+  [101] = {.lex_state = 118},
+  [102] = {.lex_state = 24},
+  [103] = {.lex_state = 8},
+  [104] = {.lex_state = 7},
+  [105] = {.lex_state = 15},
+  [106] = {.lex_state = 21},
+  [107] = {.lex_state = 15},
+  [108] = {.lex_state = 24},
+  [109] = {.lex_state = 24},
+  [110] = {.lex_state = 8},
+  [111] = {.lex_state = 8},
+  [112] = {.lex_state = 118},
+  [113] = {.lex_state = 24},
+  [114] = {.lex_state = 21},
+  [115] = {.lex_state = 24},
+  [116] = {.lex_state = 118},
+  [117] = {.lex_state = 14},
+  [118] = {.lex_state = 24},
+  [119] = {.lex_state = 14},
+  [120] = {.lex_state = 24},
+  [121] = {.lex_state = 118},
+  [122] = {.lex_state = 124},
+  [123] = {.lex_state = 124},
+  [124] = {.lex_state = 14},
+  [125] = {.lex_state = 118},
+  [126] = {.lex_state = 24},
+  [127] = {.lex_state = 24},
+  [128] = {.lex_state = 24},
+  [129] = {.lex_state = 0},
+  [130] = {.lex_state = 24},
+  [131] = {.lex_state = 24},
+  [132] = {.lex_state = 24},
+  [133] = {.lex_state = 0},
+  [134] = {.lex_state = 13},
+  [135] = {.lex_state = 24},
+  [136] = {.lex_state = 8},
+  [137] = {.lex_state = 24},
+  [138] = {.lex_state = 24},
+  [139] = {.lex_state = 0},
+  [140] = {.lex_state = 24},
+  [141] = {.lex_state = 0},
+  [142] = {.lex_state = 0},
+  [143] = {.lex_state = 0},
+  [144] = {.lex_state = 0},
+  [145] = {.lex_state = 0},
+  [146] = {.lex_state = 0},
+  [147] = {.lex_state = 0},
+  [148] = {.lex_state = 0},
+  [149] = {.lex_state = 0},
+  [150] = {.lex_state = 0},
+  [151] = {.lex_state = 20},
+  [152] = {.lex_state = 0},
+  [153] = {.lex_state = 0},
+  [154] = {.lex_state = 0},
+  [155] = {.lex_state = 0},
+  [156] = {.lex_state = 0},
+  [157] = {.lex_state = 0},
+  [158] = {.lex_state = 0},
+  [159] = {.lex_state = 121},
+  [160] = {.lex_state = 0},
+  [161] = {.lex_state = 0},
+  [162] = {.lex_state = 0},
+  [163] = {.lex_state = 0},
+  [164] = {.lex_state = 0},
+  [165] = {.lex_state = 0},
+  [166] = {.lex_state = 0},
+  [167] = {.lex_state = 0},
+  [168] = {.lex_state = 0},
+  [169] = {.lex_state = 0},
+  [170] = {.lex_state = 0},
+  [171] = {.lex_state = 0},
+  [172] = {.lex_state = 0},
+  [173] = {.lex_state = 0},
+  [174] = {.lex_state = 380},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1719,45 +4109,117 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_LBRACE] = ACTIONS(1),
     [anon_sym_RBRACE] = ACTIONS(1),
     [anon_sym_inherit] = ACTIONS(1),
-    [anon_sym_require] = ACTIONS(1),
     [anon_sym_addtask] = ACTIONS(1),
+    [anon_sym_after] = ACTIONS(1),
+    [anon_sym_before] = ACTIONS(1),
+    [anon_sym_deltask] = ACTIONS(1),
+    [anon_sym_addhandler] = ACTIONS(1),
+    [anon_sym_unset] = ACTIONS(1),
     [anon_sym_include] = ACTIONS(1),
+    [anon_sym_require] = ACTIONS(1),
+    [aux_sym__include_path_fragment_token1] = ACTIONS(1),
+    [anon_sym_EXPORT_FUNCTIONS] = ACTIONS(1),
     [anon_sym_DQUOTE] = ACTIONS(1),
+    [anon_sym_DQUOTE2] = ACTIONS(1),
     [anon_sym_SQUOTE] = ACTIONS(1),
+    [anon_sym_SQUOTE2] = ACTIONS(1),
+    [anon_sym_DOLLAR_LBRACE_AT] = ACTIONS(1),
     [anon_sym_DOLLAR_LBRACE] = ACTIONS(1),
-    [anon_sym_BSLASH_BSLASH] = ACTIONS(1),
-    [aux_sym_string_escape_token1] = ACTIONS(1),
+    [anon_sym_LBRACK] = ACTIONS(1),
+    [anon_sym_RBRACK] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
+    [anon_sym_append] = ACTIONS(1),
+    [anon_sym_prepend] = ACTIONS(1),
+    [anon_sym_remove] = ACTIONS(1),
+    [anon_sym_def] = ACTIONS(1),
     [anon_sym_POUND] = ACTIONS(1),
   },
   [1] = {
-    [sym_source_file] = STATE(65),
-    [sym__declaration] = STATE(2),
-    [sym_variable_declaration] = STATE(2),
-    [sym_task_declaration] = STATE(2),
-    [sym_python_task_declaration] = STATE(2),
-    [sym_inherit] = STATE(2),
-    [sym_require] = STATE(2),
-    [sym_addtask] = STATE(2),
-    [sym_export] = STATE(2),
-    [sym_include] = STATE(2),
-    [sym_identifier] = STATE(21),
-    [sym_comment] = STATE(2),
-    [aux_sym_source_file_repeat1] = STATE(2),
+    [sym_source_file] = STATE(173),
+    [sym__declaration] = STATE(3),
+    [sym_variable_declaration] = STATE(3),
+    [sym_shell_task_declaration] = STATE(3),
+    [sym_python_task_declaration] = STATE(3),
+    [sym_inherit] = STATE(3),
+    [sym_addtask] = STATE(3),
+    [sym_deltask] = STATE(3),
+    [sym_addhandler] = STATE(3),
+    [sym_export] = STATE(3),
+    [sym_unset] = STATE(3),
+    [sym_include] = STATE(3),
+    [sym_export_functions] = STATE(3),
+    [sym_identifier] = STATE(60),
+    [sym_variable_name] = STATE(24),
+    [sym_python_function] = STATE(3),
+    [sym_comment] = STATE(3),
+    [aux_sym_source_file_repeat1] = STATE(3),
     [ts_builtin_sym_end] = ACTIONS(3),
     [anon_sym_export] = ACTIONS(5),
     [anon_sym_python] = ACTIONS(7),
     [anon_sym_inherit] = ACTIONS(9),
-    [anon_sym_require] = ACTIONS(11),
-    [anon_sym_addtask] = ACTIONS(13),
-    [anon_sym_include] = ACTIONS(15),
-    [aux_sym_identifier_token1] = ACTIONS(17),
-    [anon_sym_POUND] = ACTIONS(19),
+    [anon_sym_addtask] = ACTIONS(11),
+    [anon_sym_deltask] = ACTIONS(13),
+    [anon_sym_addhandler] = ACTIONS(15),
+    [anon_sym_unset] = ACTIONS(17),
+    [anon_sym_include] = ACTIONS(19),
+    [anon_sym_require] = ACTIONS(19),
+    [anon_sym_EXPORT_FUNCTIONS] = ACTIONS(21),
+    [aux_sym_variable_name_token1] = ACTIONS(23),
+    [anon_sym_def] = ACTIONS(25),
+    [anon_sym_POUND] = ACTIONS(27),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 11,
+  [0] = 16,
+    ACTIONS(29), 1,
+      ts_builtin_sym_end,
+    ACTIONS(31), 1,
+      anon_sym_export,
+    ACTIONS(34), 1,
+      anon_sym_python,
+    ACTIONS(37), 1,
+      anon_sym_inherit,
+    ACTIONS(40), 1,
+      anon_sym_addtask,
+    ACTIONS(43), 1,
+      anon_sym_deltask,
+    ACTIONS(46), 1,
+      anon_sym_addhandler,
+    ACTIONS(49), 1,
+      anon_sym_unset,
+    ACTIONS(55), 1,
+      anon_sym_EXPORT_FUNCTIONS,
+    ACTIONS(58), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(61), 1,
+      anon_sym_def,
+    ACTIONS(64), 1,
+      anon_sym_POUND,
+    STATE(24), 1,
+      sym_variable_name,
+    STATE(60), 1,
+      sym_identifier,
+    ACTIONS(52), 2,
+      anon_sym_include,
+      anon_sym_require,
+    STATE(2), 15,
+      sym__declaration,
+      sym_variable_declaration,
+      sym_shell_task_declaration,
+      sym_python_task_declaration,
+      sym_inherit,
+      sym_addtask,
+      sym_deltask,
+      sym_addhandler,
+      sym_export,
+      sym_unset,
+      sym_include,
+      sym_export_functions,
+      sym_python_function,
+      sym_comment,
+      aux_sym_source_file_repeat1,
+  [64] = 16,
     ACTIONS(5), 1,
       anon_sym_export,
     ACTIONS(7), 1,
@@ -1765,202 +4227,66 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(9), 1,
       anon_sym_inherit,
     ACTIONS(11), 1,
-      anon_sym_require,
+      anon_sym_addtask,
     ACTIONS(13), 1,
-      anon_sym_addtask,
+      anon_sym_deltask,
     ACTIONS(15), 1,
-      anon_sym_include,
+      anon_sym_addhandler,
     ACTIONS(17), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(19), 1,
-      anon_sym_POUND,
+      anon_sym_unset,
     ACTIONS(21), 1,
-      ts_builtin_sym_end,
-    STATE(21), 1,
-      sym_identifier,
-    STATE(3), 11,
-      sym__declaration,
-      sym_variable_declaration,
-      sym_task_declaration,
-      sym_python_task_declaration,
-      sym_inherit,
-      sym_require,
-      sym_addtask,
-      sym_export,
-      sym_include,
-      sym_comment,
-      aux_sym_source_file_repeat1,
-  [44] = 11,
+      anon_sym_EXPORT_FUNCTIONS,
     ACTIONS(23), 1,
-      ts_builtin_sym_end,
+      aux_sym_variable_name_token1,
     ACTIONS(25), 1,
-      anon_sym_export,
-    ACTIONS(28), 1,
-      anon_sym_python,
-    ACTIONS(31), 1,
-      anon_sym_inherit,
-    ACTIONS(34), 1,
-      anon_sym_require,
-    ACTIONS(37), 1,
-      anon_sym_addtask,
-    ACTIONS(40), 1,
-      anon_sym_include,
-    ACTIONS(43), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(46), 1,
+      anon_sym_def,
+    ACTIONS(27), 1,
       anon_sym_POUND,
-    STATE(21), 1,
+    ACTIONS(67), 1,
+      ts_builtin_sym_end,
+    STATE(24), 1,
+      sym_variable_name,
+    STATE(60), 1,
       sym_identifier,
-    STATE(3), 11,
+    ACTIONS(19), 2,
+      anon_sym_include,
+      anon_sym_require,
+    STATE(2), 15,
       sym__declaration,
       sym_variable_declaration,
-      sym_task_declaration,
+      sym_shell_task_declaration,
       sym_python_task_declaration,
       sym_inherit,
-      sym_require,
       sym_addtask,
+      sym_deltask,
+      sym_addhandler,
       sym_export,
+      sym_unset,
       sym_include,
+      sym_export_functions,
+      sym_python_function,
       sym_comment,
       aux_sym_source_file_repeat1,
-  [88] = 4,
-    ACTIONS(51), 1,
-      aux_sym_addtask_token1,
-    ACTIONS(53), 1,
-      anon_sym_COLON,
-    STATE(6), 2,
-      sym_override,
-      aux_sym_identifier_repeat1,
-    ACTIONS(49), 9,
-      anon_sym_EQ,
-      anon_sym_DOT_EQ,
-      anon_sym_PLUS_EQ,
-      anon_sym_COLON_EQ,
-      anon_sym_QMARK_EQ,
-      anon_sym_QMARK_QMARK_EQ,
-      anon_sym_EQ_PLUS,
-      anon_sym_EQ_DOT,
-      aux_sym_identifier_token1,
-  [110] = 4,
-    ACTIONS(57), 1,
-      aux_sym_addtask_token1,
-    ACTIONS(59), 1,
-      anon_sym_COLON,
-    STATE(5), 2,
-      sym_override,
-      aux_sym_identifier_repeat1,
-    ACTIONS(55), 9,
-      anon_sym_EQ,
-      anon_sym_DOT_EQ,
-      anon_sym_PLUS_EQ,
-      anon_sym_COLON_EQ,
-      anon_sym_QMARK_EQ,
-      anon_sym_QMARK_QMARK_EQ,
-      anon_sym_EQ_PLUS,
-      anon_sym_EQ_DOT,
-      aux_sym_identifier_token1,
-  [132] = 4,
-    ACTIONS(53), 1,
-      anon_sym_COLON,
-    ACTIONS(64), 1,
-      aux_sym_addtask_token1,
-    STATE(5), 2,
-      sym_override,
-      aux_sym_identifier_repeat1,
-    ACTIONS(62), 9,
-      anon_sym_EQ,
-      anon_sym_DOT_EQ,
-      anon_sym_PLUS_EQ,
-      anon_sym_COLON_EQ,
-      anon_sym_QMARK_EQ,
-      anon_sym_QMARK_QMARK_EQ,
-      anon_sym_EQ_PLUS,
-      anon_sym_EQ_DOT,
-      aux_sym_identifier_token1,
-  [154] = 4,
-    ACTIONS(49), 1,
-      anon_sym_EQ,
-    ACTIONS(66), 1,
-      anon_sym_COLON,
-    STATE(9), 2,
-      sym_override,
-      aux_sym_identifier_repeat1,
-    ACTIONS(51), 8,
-      anon_sym_DOT_EQ,
-      anon_sym_PLUS_EQ,
-      anon_sym_COLON_EQ,
-      anon_sym_QMARK_EQ,
-      anon_sym_QMARK_QMARK_EQ,
-      anon_sym_EQ_PLUS,
-      anon_sym_EQ_DOT,
-      anon_sym_LPAREN,
-  [175] = 4,
-    ACTIONS(55), 1,
-      anon_sym_EQ,
-    ACTIONS(68), 1,
-      anon_sym_COLON,
-    STATE(8), 2,
-      sym_override,
-      aux_sym_identifier_repeat1,
-    ACTIONS(57), 8,
-      anon_sym_DOT_EQ,
-      anon_sym_PLUS_EQ,
-      anon_sym_COLON_EQ,
-      anon_sym_QMARK_EQ,
-      anon_sym_QMARK_QMARK_EQ,
-      anon_sym_EQ_PLUS,
-      anon_sym_EQ_DOT,
-      anon_sym_LPAREN,
-  [196] = 4,
-    ACTIONS(62), 1,
-      anon_sym_EQ,
-    ACTIONS(66), 1,
-      anon_sym_COLON,
-    STATE(8), 2,
-      sym_override,
-      aux_sym_identifier_repeat1,
-    ACTIONS(64), 8,
-      anon_sym_DOT_EQ,
-      anon_sym_PLUS_EQ,
-      anon_sym_COLON_EQ,
-      anon_sym_QMARK_EQ,
-      anon_sym_QMARK_QMARK_EQ,
-      anon_sym_EQ_PLUS,
-      anon_sym_EQ_DOT,
-      anon_sym_LPAREN,
-  [217] = 2,
+  [128] = 7,
     ACTIONS(73), 1,
-      aux_sym_addtask_token1,
-    ACTIONS(71), 10,
-      anon_sym_EQ,
-      anon_sym_DOT_EQ,
-      anon_sym_PLUS_EQ,
-      anon_sym_COLON_EQ,
-      anon_sym_QMARK_EQ,
-      anon_sym_QMARK_QMARK_EQ,
-      anon_sym_EQ_PLUS,
-      anon_sym_EQ_DOT,
-      anon_sym_COLON,
-      aux_sym_identifier_token1,
-  [233] = 3,
+      aux_sym__include_path_fragment_token1,
+    ACTIONS(75), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
     ACTIONS(77), 1,
-      aux_sym_addtask_token1,
+      anon_sym_DOLLAR_LBRACE,
     ACTIONS(79), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(75), 8,
-      anon_sym_EQ,
-      anon_sym_DOT_EQ,
-      anon_sym_PLUS_EQ,
-      anon_sym_COLON_EQ,
-      anon_sym_QMARK_EQ,
-      anon_sym_QMARK_QMARK_EQ,
-      anon_sym_EQ_PLUS,
-      anon_sym_EQ_DOT,
-  [250] = 2,
+      aux_sym__variable_fragment_token1,
     ACTIONS(71), 2,
+      aux_sym_addtask_token1,
+      anon_sym_LBRACK,
+    STATE(6), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+    ACTIONS(69), 10,
       anon_sym_EQ,
-      anon_sym_COLON,
-    ACTIONS(73), 8,
       anon_sym_DOT_EQ,
       anon_sym_PLUS_EQ,
       anon_sym_COLON_EQ,
@@ -1968,109 +4294,85 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_QMARK_QMARK_EQ,
       anon_sym_EQ_PLUS,
       anon_sym_EQ_DOT,
-      anon_sym_LPAREN,
-  [265] = 2,
+      anon_sym_COLON,
+      aux_sym_variable_name_token1,
+  [164] = 7,
+    ACTIONS(85), 1,
+      aux_sym__include_path_fragment_token1,
+    ACTIONS(88), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(91), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(94), 1,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(83), 2,
+      aux_sym_addtask_token1,
+      anon_sym_LBRACK,
+    STATE(5), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+    ACTIONS(81), 10,
+      anon_sym_EQ,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_COLON,
+      aux_sym_variable_name_token1,
+  [200] = 7,
+    ACTIONS(75), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(77), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(101), 1,
+      aux_sym__include_path_fragment_token1,
+    ACTIONS(103), 1,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(99), 2,
+      aux_sym_addtask_token1,
+      anon_sym_LBRACK,
+    STATE(5), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+    ACTIONS(97), 10,
+      anon_sym_EQ,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_COLON,
+      aux_sym_variable_name_token1,
+  [236] = 7,
+    ACTIONS(105), 1,
+      aux_sym__include_path_fragment_token1,
+    ACTIONS(108), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(111), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(114), 1,
+      aux_sym__variable_fragment_token1,
     ACTIONS(81), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(83), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [279] = 2,
-    ACTIONS(85), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(87), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [293] = 2,
-    ACTIONS(89), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(91), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [307] = 2,
-    ACTIONS(93), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(95), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [321] = 2,
-    ACTIONS(97), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(99), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [335] = 2,
-    ACTIONS(101), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(103), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [349] = 2,
-    ACTIONS(105), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(107), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [363] = 2,
-    ACTIONS(109), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(111), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [377] = 3,
-    ACTIONS(113), 1,
       anon_sym_EQ,
-    ACTIONS(117), 1,
-      anon_sym_LPAREN,
-    ACTIONS(115), 7,
+      anon_sym_COLON,
+    STATE(7), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+    ACTIONS(83), 9,
       anon_sym_DOT_EQ,
       anon_sym_PLUS_EQ,
       anon_sym_COLON_EQ,
@@ -2078,607 +4380,2252 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_QMARK_QMARK_EQ,
       anon_sym_EQ_PLUS,
       anon_sym_EQ_DOT,
-  [393] = 2,
-    ACTIONS(119), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(121), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [407] = 2,
-    ACTIONS(123), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(125), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [421] = 2,
-    ACTIONS(127), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(129), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [435] = 2,
-    ACTIONS(131), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(133), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [449] = 2,
-    ACTIONS(135), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(137), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [463] = 2,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+  [271] = 7,
+    ACTIONS(117), 1,
+      aux_sym__include_path_fragment_token1,
+    ACTIONS(119), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(121), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(123), 1,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(97), 2,
+      anon_sym_EQ,
+      anon_sym_COLON,
+    STATE(7), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+    ACTIONS(99), 9,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+  [306] = 7,
+    ACTIONS(119), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(121), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(125), 1,
+      aux_sym__include_path_fragment_token1,
+    ACTIONS(127), 1,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(69), 2,
+      anon_sym_EQ,
+      anon_sym_COLON,
+    STATE(8), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+    ACTIONS(71), 9,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+      anon_sym_LBRACK,
+  [341] = 6,
+    ACTIONS(135), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(137), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(129), 2,
+      anon_sym_EQ,
+      anon_sym_COLON,
+    ACTIONS(133), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__override_fragment_token1,
+    STATE(11), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__override_fragment,
+      aux_sym_override_repeat1,
+    ACTIONS(131), 8,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+  [373] = 6,
+    ACTIONS(146), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(149), 1,
+      anon_sym_DOLLAR_LBRACE,
     ACTIONS(139), 2,
-      ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(141), 7,
-      anon_sym_export,
-      anon_sym_python,
-      anon_sym_inherit,
-      anon_sym_require,
-      anon_sym_addtask,
-      anon_sym_include,
-      aux_sym_identifier_token1,
-  [477] = 2,
+      anon_sym_EQ,
+      anon_sym_COLON,
     ACTIONS(143), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__override_fragment_token1,
+    STATE(11), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__override_fragment,
+      aux_sym_override_repeat1,
+    ACTIONS(141), 8,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+  [405] = 4,
+    ACTIONS(152), 1,
       ts_builtin_sym_end,
-      anon_sym_POUND,
-    ACTIONS(145), 7,
+    ACTIONS(156), 1,
+      sym__python_code,
+    STATE(14), 1,
+      aux_sym_python_function_repeat1,
+    ACTIONS(154), 13,
       anon_sym_export,
       anon_sym_python,
       anon_sym_inherit,
-      anon_sym_require,
       anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
       anon_sym_include,
-      aux_sym_identifier_token1,
-  [491] = 2,
-    ACTIONS(147), 2,
-      ts_builtin_sym_end,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
       anon_sym_POUND,
-    ACTIONS(149), 7,
+  [430] = 4,
+    ACTIONS(158), 1,
+      ts_builtin_sym_end,
+    ACTIONS(162), 1,
+      sym__python_code,
+    STATE(12), 1,
+      aux_sym_python_function_repeat1,
+    ACTIONS(160), 13,
       anon_sym_export,
       anon_sym_python,
       anon_sym_inherit,
-      anon_sym_require,
       anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
       anon_sym_include,
-      aux_sym_identifier_token1,
-  [505] = 2,
-    ACTIONS(151), 2,
-      ts_builtin_sym_end,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
       anon_sym_POUND,
-    ACTIONS(153), 7,
+  [455] = 4,
+    ACTIONS(164), 1,
+      ts_builtin_sym_end,
+    ACTIONS(168), 1,
+      sym__python_code,
+    STATE(14), 1,
+      aux_sym_python_function_repeat1,
+    ACTIONS(166), 13,
       anon_sym_export,
       anon_sym_python,
       anon_sym_inherit,
-      anon_sym_require,
       anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
       anon_sym_include,
-      aux_sym_identifier_token1,
-  [519] = 5,
-    ACTIONS(155), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(157), 1,
-      aux_sym_string_token1,
-    ACTIONS(159), 1,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+      anon_sym_POUND,
+  [480] = 2,
+    ACTIONS(173), 4,
+      aux_sym_addtask_token1,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      anon_sym_LBRACK,
+    ACTIONS(171), 12,
+      anon_sym_EQ,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
       anon_sym_DOLLAR_LBRACE,
-    ACTIONS(161), 1,
-      anon_sym_BSLASH_BSLASH,
-    STATE(32), 3,
-      sym_string_expansion,
-      sym_string_escape,
-      aux_sym_string_repeat1,
-  [537] = 5,
-    ACTIONS(159), 1,
+      anon_sym_COLON,
+      aux_sym_variable_name_token1,
+      aux_sym__variable_fragment_token1,
+  [501] = 2,
+    ACTIONS(177), 4,
+      aux_sym_addtask_token1,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      anon_sym_LBRACK,
+    ACTIONS(175), 12,
+      anon_sym_EQ,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
       anon_sym_DOLLAR_LBRACE,
-    ACTIONS(161), 1,
-      anon_sym_BSLASH_BSLASH,
-    ACTIONS(163), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(165), 1,
-      aux_sym_string_token1,
-    STATE(33), 3,
-      sym_string_expansion,
-      sym_string_escape,
-      aux_sym_string_repeat1,
-  [555] = 5,
-    ACTIONS(167), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(169), 1,
-      aux_sym_string_token1,
-    ACTIONS(172), 1,
+      anon_sym_COLON,
+      aux_sym_variable_name_token1,
+      aux_sym__variable_fragment_token1,
+  [522] = 2,
+    ACTIONS(175), 4,
+      anon_sym_EQ,
       anon_sym_DOLLAR_LBRACE,
+      anon_sym_COLON,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(177), 11,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      anon_sym_LBRACK,
+  [542] = 2,
+    ACTIONS(171), 4,
+      anon_sym_EQ,
+      anon_sym_DOLLAR_LBRACE,
+      anon_sym_COLON,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(173), 11,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      anon_sym_LBRACK,
+  [562] = 7,
+    ACTIONS(181), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(183), 1,
+      anon_sym_LBRACK,
+    ACTIONS(185), 1,
+      anon_sym_COLON,
+    ACTIONS(187), 1,
+      aux_sym_variable_name_token1,
+    STATE(61), 1,
+      sym_flag,
+    STATE(47), 2,
+      sym_override,
+      aux_sym_identifier_repeat1,
+    ACTIONS(179), 8,
+      anon_sym_EQ,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+  [592] = 2,
+    ACTIONS(189), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(191), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [611] = 2,
+    ACTIONS(193), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(195), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [630] = 2,
+    ACTIONS(197), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(199), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [649] = 2,
+    ACTIONS(175), 3,
+      anon_sym_EQ,
+      anon_sym_DOLLAR_LBRACE,
+      anon_sym_COLON,
+    ACTIONS(177), 11,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      aux_sym__override_fragment_token1,
+  [668] = 6,
+    ACTIONS(179), 1,
+      anon_sym_EQ,
+    ACTIONS(183), 1,
+      anon_sym_LBRACK,
+    ACTIONS(185), 1,
+      anon_sym_COLON,
+    STATE(61), 1,
+      sym_flag,
+    STATE(47), 2,
+      sym_override,
+      aux_sym_identifier_repeat1,
+    ACTIONS(201), 8,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+  [695] = 2,
+    ACTIONS(203), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(205), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [714] = 2,
+    ACTIONS(207), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(209), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [733] = 2,
+    ACTIONS(211), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(213), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [752] = 2,
+    ACTIONS(215), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(217), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [771] = 2,
+    ACTIONS(219), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(221), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [790] = 2,
+    ACTIONS(223), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(225), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [809] = 2,
+    ACTIONS(227), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(229), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [828] = 2,
+    ACTIONS(171), 3,
+      anon_sym_EQ,
+      anon_sym_DOLLAR_LBRACE,
+      anon_sym_COLON,
+    ACTIONS(173), 11,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      aux_sym__override_fragment_token1,
+  [847] = 2,
+    ACTIONS(231), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(233), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [866] = 2,
+    ACTIONS(235), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(237), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [885] = 2,
+    ACTIONS(239), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(241), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [904] = 2,
+    ACTIONS(243), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(245), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [923] = 2,
+    ACTIONS(247), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(249), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [942] = 2,
+    ACTIONS(251), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(253), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [961] = 2,
+    ACTIONS(255), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(257), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [980] = 2,
+    ACTIONS(259), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND,
+    ACTIONS(261), 12,
+      anon_sym_export,
+      anon_sym_python,
+      anon_sym_inherit,
+      anon_sym_addtask,
+      anon_sym_deltask,
+      anon_sym_addhandler,
+      anon_sym_unset,
+      anon_sym_include,
+      anon_sym_require,
+      anon_sym_EXPORT_FUNCTIONS,
+      aux_sym_variable_name_token1,
+      anon_sym_def,
+  [999] = 7,
+    ACTIONS(83), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(263), 1,
+      aux_sym__include_path_fragment_token1,
+    ACTIONS(266), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(269), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(272), 1,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(81), 3,
+      anon_sym_after,
+      anon_sym_before,
+      aux_sym_variable_name_token1,
+    STATE(41), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1027] = 7,
+    ACTIONS(71), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(275), 1,
+      aux_sym__include_path_fragment_token1,
+    ACTIONS(277), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(279), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(281), 1,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(69), 3,
+      anon_sym_after,
+      anon_sym_before,
+      aux_sym_variable_name_token1,
+    STATE(45), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1055] = 5,
+    ACTIONS(285), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(287), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(283), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(71), 4,
+      anon_sym_LPAREN,
+      anon_sym_RBRACE,
+      anon_sym_LBRACK,
+      anon_sym_COLON,
+    STATE(44), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1079] = 5,
+    ACTIONS(285), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(287), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(289), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(99), 4,
+      anon_sym_LPAREN,
+      anon_sym_RBRACE,
+      anon_sym_LBRACK,
+      anon_sym_COLON,
+    STATE(46), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1103] = 7,
+    ACTIONS(99), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(277), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(279), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(291), 1,
+      aux_sym__include_path_fragment_token1,
+    ACTIONS(293), 1,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(97), 3,
+      anon_sym_after,
+      anon_sym_before,
+      aux_sym_variable_name_token1,
+    STATE(41), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1131] = 5,
+    ACTIONS(298), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(301), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(295), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__variable_fragment_token1,
+    ACTIONS(83), 4,
+      anon_sym_LPAREN,
+      anon_sym_RBRACE,
+      anon_sym_LBRACK,
+      anon_sym_COLON,
+    STATE(46), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1155] = 4,
+    ACTIONS(185), 1,
+      anon_sym_COLON,
+    ACTIONS(304), 1,
+      anon_sym_EQ,
+    STATE(49), 2,
+      sym_override,
+      aux_sym_identifier_repeat1,
+    ACTIONS(306), 8,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+  [1176] = 6,
+    ACTIONS(135), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(137), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(308), 1,
+      aux_sym__include_path_fragment_token1,
+    ACTIONS(312), 1,
+      aux_sym__override_fragment_token1,
+    ACTIONS(310), 3,
+      anon_sym_append,
+      anon_sym_prepend,
+      anon_sym_remove,
+    STATE(10), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__override_fragment,
+      aux_sym_override_repeat1,
+  [1201] = 4,
+    ACTIONS(314), 1,
+      anon_sym_EQ,
+    ACTIONS(318), 1,
+      anon_sym_COLON,
+    STATE(49), 2,
+      sym_override,
+      aux_sym_identifier_repeat1,
+    ACTIONS(316), 8,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+  [1222] = 6,
+    ACTIONS(69), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(71), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(323), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(325), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(321), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__variable_fragment_token1,
+    STATE(51), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1246] = 6,
+    ACTIONS(97), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(99), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(323), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(325), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(327), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__variable_fragment_token1,
+    STATE(55), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1270] = 6,
+    ACTIONS(81), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(83), 1,
+      anon_sym_LF,
+    ACTIONS(332), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(335), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(329), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__variable_fragment_token1,
+    STATE(52), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1294] = 6,
+    ACTIONS(97), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(99), 1,
+      anon_sym_LF,
+    ACTIONS(340), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(342), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(338), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__variable_fragment_token1,
+    STATE(52), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1318] = 6,
+    ACTIONS(69), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(71), 1,
+      anon_sym_LF,
+    ACTIONS(340), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(342), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(344), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__variable_fragment_token1,
+    STATE(53), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1342] = 6,
+    ACTIONS(81), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(83), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(349), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(352), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(346), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__variable_fragment_token1,
+    STATE(55), 5,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+      sym__variable_fragment,
+      aux_sym_variable_name_repeat1,
+  [1366] = 2,
+    ACTIONS(129), 2,
+      anon_sym_EQ,
+      anon_sym_COLON,
+    ACTIONS(131), 8,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+  [1381] = 6,
+    ACTIONS(355), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(360), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(363), 1,
+      anon_sym_DOLLAR_LBRACE,
+    STATE(57), 1,
+      aux_sym_include_repeat1,
+    ACTIONS(357), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__include_path_fragment_token2,
+    STATE(96), 4,
+      sym__include_path_fragment,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+  [1404] = 6,
+    ACTIONS(366), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(370), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(372), 1,
+      anon_sym_DOLLAR_LBRACE,
+    STATE(57), 1,
+      aux_sym_include_repeat1,
+    ACTIONS(368), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__include_path_fragment_token2,
+    STATE(96), 4,
+      sym__include_path_fragment,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+  [1427] = 5,
+    ACTIONS(370), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(372), 1,
+      anon_sym_DOLLAR_LBRACE,
+    STATE(58), 1,
+      aux_sym_include_repeat1,
+    ACTIONS(368), 2,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__include_path_fragment_token2,
+    STATE(96), 4,
+      sym__include_path_fragment,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+  [1447] = 3,
+    ACTIONS(374), 1,
+      anon_sym_EQ,
+    ACTIONS(378), 1,
+      anon_sym_LPAREN,
+    ACTIONS(376), 7,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+  [1463] = 2,
+    ACTIONS(304), 1,
+      anon_sym_EQ,
+    ACTIONS(306), 8,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+  [1477] = 2,
+    ACTIONS(380), 1,
+      anon_sym_EQ,
+    ACTIONS(382), 8,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+      anon_sym_LPAREN,
+  [1491] = 5,
+    ACTIONS(384), 1,
+      anon_sym_DQUOTE2,
+    ACTIONS(386), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(388), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(390), 1,
+      sym_string_text_fragment1,
+    STATE(67), 4,
+      aux_sym__string_inner1,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+  [1510] = 5,
+    ACTIONS(386), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(388), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(392), 1,
+      anon_sym_DQUOTE2,
+    ACTIONS(394), 1,
+      sym_string_text_fragment1,
+    STATE(63), 4,
+      aux_sym__string_inner1,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+  [1529] = 5,
+    ACTIONS(392), 1,
+      anon_sym_SQUOTE2,
+    ACTIONS(396), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(398), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(400), 1,
+      sym_string_text_fragment2,
+    STATE(73), 4,
+      aux_sym__string_inner2,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+  [1548] = 5,
+    ACTIONS(402), 1,
+      anon_sym_SQUOTE2,
+    ACTIONS(404), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(407), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(410), 1,
+      sym_string_text_fragment2,
+    STATE(66), 4,
+      aux_sym__string_inner2,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+  [1567] = 5,
+    ACTIONS(413), 1,
+      anon_sym_DQUOTE2,
+    ACTIONS(415), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(418), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(421), 1,
+      sym_string_text_fragment1,
+    STATE(67), 4,
+      aux_sym__string_inner1,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+  [1586] = 2,
+    ACTIONS(173), 3,
+      aux_sym_addtask_token1,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(171), 5,
+      anon_sym_after,
+      anon_sym_before,
+      anon_sym_DOLLAR_LBRACE,
+      aux_sym_variable_name_token1,
+      aux_sym__variable_fragment_token1,
+  [1599] = 2,
     ACTIONS(175), 1,
-      anon_sym_BSLASH_BSLASH,
-    STATE(33), 3,
-      sym_string_expansion,
-      sym_string_escape,
-      aux_sym_string_repeat1,
-  [573] = 4,
-    ACTIONS(62), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(64), 1,
-      aux_sym_addtask_token1,
-    ACTIONS(178), 1,
-      anon_sym_COLON,
-    STATE(36), 2,
-      sym_override,
-      aux_sym_identifier_repeat1,
-  [587] = 4,
-    ACTIONS(49), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(51), 1,
-      aux_sym_addtask_token1,
-    ACTIONS(178), 1,
-      anon_sym_COLON,
-    STATE(34), 2,
-      sym_override,
-      aux_sym_identifier_repeat1,
-  [601] = 4,
-    ACTIONS(55), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(57), 1,
-      aux_sym_addtask_token1,
-    ACTIONS(180), 1,
-      anon_sym_COLON,
-    STATE(36), 2,
-      sym_override,
-      aux_sym_identifier_repeat1,
-  [615] = 1,
-    ACTIONS(183), 4,
-      anon_sym_DQUOTE,
-      aux_sym_string_token1,
       anon_sym_DOLLAR_LBRACE,
-      anon_sym_BSLASH_BSLASH,
-  [622] = 4,
-    ACTIONS(185), 1,
-      anon_sym_DQUOTE,
-    ACTIONS(187), 1,
-      anon_sym_SQUOTE,
-    STATE(28), 1,
-      sym_string2,
-    STATE(30), 1,
-      sym_string,
-  [635] = 1,
-    ACTIONS(189), 4,
-      anon_sym_DQUOTE,
-      aux_sym_string_token1,
+    ACTIONS(177), 7,
+      anon_sym_LPAREN,
+      anon_sym_RBRACE,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      anon_sym_LBRACK,
+      anon_sym_COLON,
+      aux_sym__variable_fragment_token1,
+  [1612] = 2,
+    ACTIONS(171), 1,
       anon_sym_DOLLAR_LBRACE,
-      anon_sym_BSLASH_BSLASH,
-  [642] = 3,
-    ACTIONS(191), 1,
+    ACTIONS(173), 7,
+      anon_sym_LPAREN,
       anon_sym_RBRACE,
-    ACTIONS(193), 1,
-      aux_sym_statement_token1,
-    STATE(43), 2,
-      sym_statement,
-      aux_sym_block_repeat1,
-  [653] = 3,
-    ACTIONS(195), 1,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      anon_sym_LBRACK,
+      anon_sym_COLON,
+      aux_sym__variable_fragment_token1,
+  [1625] = 2,
+    ACTIONS(177), 3,
       aux_sym_addtask_token1,
-    ACTIONS(197), 1,
-      aux_sym_identifier_token1,
-    STATE(42), 2,
-      sym_identifier,
-      aux_sym_addtask_repeat1,
-  [664] = 3,
-    ACTIONS(199), 1,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(175), 5,
+      anon_sym_after,
+      anon_sym_before,
+      anon_sym_DOLLAR_LBRACE,
+      aux_sym_variable_name_token1,
+      aux_sym__variable_fragment_token1,
+  [1638] = 2,
+    ACTIONS(424), 1,
+      anon_sym_EQ,
+    ACTIONS(426), 7,
+      anon_sym_DOT_EQ,
+      anon_sym_PLUS_EQ,
+      anon_sym_COLON_EQ,
+      anon_sym_QMARK_EQ,
+      anon_sym_QMARK_QMARK_EQ,
+      anon_sym_EQ_PLUS,
+      anon_sym_EQ_DOT,
+  [1651] = 5,
+    ACTIONS(384), 1,
+      anon_sym_SQUOTE2,
+    ACTIONS(396), 1,
+      anon_sym_DOLLAR_LBRACE_AT,
+    ACTIONS(398), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(428), 1,
+      sym_string_text_fragment2,
+    STATE(66), 4,
+      aux_sym__string_inner2,
+      sym__expansion,
+      sym_python_expansion,
+      sym_shell_expansion,
+  [1670] = 5,
+    ACTIONS(432), 1,
       aux_sym_addtask_token1,
-    ACTIONS(201), 1,
-      aux_sym_identifier_token1,
-    STATE(42), 2,
-      sym_identifier,
+    ACTIONS(434), 1,
+      aux_sym_variable_name_token1,
+    STATE(104), 1,
+      sym_variable_name,
+    ACTIONS(430), 2,
+      anon_sym_after,
+      anon_sym_before,
+    STATE(75), 2,
+      sym_function_name,
       aux_sym_addtask_repeat1,
-  [675] = 3,
-    ACTIONS(204), 1,
+  [1688] = 5,
+    ACTIONS(439), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(441), 1,
+      aux_sym_variable_name_token1,
+    STATE(104), 1,
+      sym_variable_name,
+    ACTIONS(436), 2,
+      anon_sym_after,
+      anon_sym_before,
+    STATE(75), 2,
+      sym_function_name,
+      aux_sym_addtask_repeat1,
+  [1706] = 2,
+    ACTIONS(175), 2,
+      anon_sym_DOLLAR_LBRACE,
+      aux_sym_variable_name_token1,
+    ACTIONS(177), 4,
+      anon_sym_LF,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      aux_sym__variable_fragment_token1,
+  [1717] = 4,
+    ACTIONS(434), 1,
+      aux_sym_variable_name_token1,
+    STATE(104), 1,
+      sym_variable_name,
+    ACTIONS(444), 2,
+      anon_sym_after,
+      anon_sym_before,
+    STATE(74), 2,
+      sym_function_name,
+      aux_sym_addtask_repeat1,
+  [1732] = 2,
+    ACTIONS(175), 2,
+      anon_sym_DOLLAR_LBRACE,
+      aux_sym_variable_name_token1,
+    ACTIONS(177), 4,
+      aux_sym_addtask_token1,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      aux_sym__variable_fragment_token1,
+  [1743] = 2,
+    ACTIONS(171), 2,
+      anon_sym_DOLLAR_LBRACE,
+      aux_sym_variable_name_token1,
+    ACTIONS(173), 4,
+      aux_sym_addtask_token1,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      aux_sym__variable_fragment_token1,
+  [1754] = 2,
+    ACTIONS(171), 2,
+      anon_sym_DOLLAR_LBRACE,
+      aux_sym_variable_name_token1,
+    ACTIONS(173), 4,
+      anon_sym_LF,
+      aux_sym__include_path_fragment_token1,
+      anon_sym_DOLLAR_LBRACE_AT,
+      aux_sym__variable_fragment_token1,
+  [1765] = 4,
+    ACTIONS(446), 1,
+      anon_sym_LBRACE,
+    ACTIONS(448), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(160), 1,
+      sym_inline_code,
+    STATE(90), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [1779] = 4,
+    ACTIONS(450), 1,
+      anon_sym_LF,
+    ACTIONS(452), 1,
+      aux_sym_variable_name_token1,
+    STATE(134), 1,
+      sym_variable_name,
+    STATE(89), 2,
+      sym_class_name,
+      aux_sym_inherit_repeat1,
+  [1793] = 4,
+    ACTIONS(454), 1,
+      anon_sym_LBRACE,
+    ACTIONS(457), 1,
       anon_sym_RBRACE,
-    ACTIONS(206), 1,
-      aux_sym_statement_token1,
-    STATE(43), 2,
-      sym_statement,
-      aux_sym_block_repeat1,
-  [686] = 4,
-    ACTIONS(185), 1,
+    ACTIONS(459), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(83), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [1807] = 4,
+    ACTIONS(446), 1,
+      anon_sym_LBRACE,
+    ACTIONS(448), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(155), 1,
+      sym_inline_code,
+    STATE(90), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [1821] = 4,
+    ACTIONS(446), 1,
+      anon_sym_LBRACE,
+    ACTIONS(448), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(143), 1,
+      sym_inline_code,
+    STATE(90), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [1835] = 4,
+    ACTIONS(446), 1,
+      anon_sym_LBRACE,
+    ACTIONS(448), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(164), 1,
+      sym_inline_code,
+    STATE(90), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [1849] = 4,
+    ACTIONS(446), 1,
+      anon_sym_LBRACE,
+    ACTIONS(448), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(145), 1,
+      sym_inline_code,
+    STATE(90), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [1863] = 2,
+    ACTIONS(175), 2,
+      aux_sym_addtask_token1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(177), 3,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__include_path_fragment_token2,
+      anon_sym_DOLLAR_LBRACE_AT,
+  [1873] = 4,
+    ACTIONS(462), 1,
+      anon_sym_LF,
+    ACTIONS(464), 1,
+      aux_sym_variable_name_token1,
+    STATE(134), 1,
+      sym_variable_name,
+    STATE(89), 2,
+      sym_class_name,
+      aux_sym_inherit_repeat1,
+  [1887] = 4,
+    ACTIONS(446), 1,
+      anon_sym_LBRACE,
+    ACTIONS(467), 1,
+      anon_sym_RBRACE,
+    ACTIONS(469), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(83), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [1901] = 4,
+    ACTIONS(446), 1,
+      anon_sym_LBRACE,
+    ACTIONS(448), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(169), 1,
+      sym_inline_code,
+    STATE(90), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [1915] = 4,
+    ACTIONS(446), 1,
+      anon_sym_LBRACE,
+    ACTIONS(448), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(147), 1,
+      sym_inline_code,
+    STATE(90), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [1929] = 4,
+    ACTIONS(471), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(473), 1,
+      aux_sym_variable_name_token1,
+    STATE(136), 1,
+      sym_variable_name,
+    STATE(93), 2,
+      sym_function_name,
+      aux_sym_deltask_repeat1,
+  [1943] = 4,
+    ACTIONS(476), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(478), 1,
+      aux_sym_variable_name_token1,
+    STATE(136), 1,
+      sym_variable_name,
+    STATE(93), 2,
+      sym_function_name,
+      aux_sym_deltask_repeat1,
+  [1957] = 2,
+    ACTIONS(171), 2,
+      aux_sym_addtask_token1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(173), 3,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__include_path_fragment_token2,
+      anon_sym_DOLLAR_LBRACE_AT,
+  [1967] = 2,
+    ACTIONS(480), 2,
+      aux_sym_addtask_token1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(482), 3,
+      aux_sym__include_path_fragment_token1,
+      aux_sym__include_path_fragment_token2,
+      anon_sym_DOLLAR_LBRACE_AT,
+  [1977] = 4,
+    ACTIONS(446), 1,
+      anon_sym_LBRACE,
+    ACTIONS(448), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(149), 1,
+      sym_inline_code,
+    STATE(90), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [1991] = 4,
+    ACTIONS(446), 1,
+      anon_sym_LBRACE,
+    ACTIONS(448), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(141), 1,
+      sym_inline_code,
+    STATE(90), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [2005] = 4,
+    ACTIONS(478), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(484), 1,
+      aux_sym_addtask_token1,
+    STATE(136), 1,
+      sym_variable_name,
+    STATE(93), 2,
+      sym_function_name,
+      aux_sym_deltask_repeat1,
+  [2019] = 4,
+    ACTIONS(478), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(486), 1,
+      aux_sym_addtask_token1,
+    STATE(136), 1,
+      sym_variable_name,
+    STATE(93), 2,
+      sym_function_name,
+      aux_sym_deltask_repeat1,
+  [2033] = 4,
+    ACTIONS(446), 1,
+      anon_sym_LBRACE,
+    ACTIONS(448), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(153), 1,
+      sym_inline_code,
+    STATE(90), 2,
+      sym__inline_code_inner,
+      aux_sym_inline_code_repeat1,
+  [2047] = 4,
+    ACTIONS(488), 1,
+      anon_sym_LPAREN,
+    ACTIONS(490), 1,
+      aux_sym_variable_name_token1,
+    STATE(24), 1,
+      sym_variable_name,
+    STATE(170), 1,
+      sym_identifier,
+  [2060] = 3,
+    ACTIONS(492), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(494), 1,
+      aux_sym_variable_name_token1,
+    STATE(103), 2,
+      sym_variable_name,
+      aux_sym_export_repeat1,
+  [2071] = 2,
+    ACTIONS(499), 1,
+      aux_sym_addtask_token1,
+    ACTIONS(497), 3,
+      anon_sym_after,
+      anon_sym_before,
+      aux_sym_variable_name_token1,
+  [2080] = 2,
+    ACTIONS(171), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(173), 3,
+      anon_sym_DQUOTE2,
+      anon_sym_DOLLAR_LBRACE_AT,
+      sym_string_text_fragment1,
+  [2089] = 2,
+    ACTIONS(175), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(177), 3,
+      anon_sym_SQUOTE2,
+      anon_sym_DOLLAR_LBRACE_AT,
+      sym_string_text_fragment2,
+  [2098] = 2,
+    ACTIONS(175), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(177), 3,
+      anon_sym_DQUOTE2,
+      anon_sym_DOLLAR_LBRACE_AT,
+      sym_string_text_fragment1,
+  [2107] = 4,
+    ACTIONS(501), 1,
+      aux_sym_variable_name_token1,
+    STATE(19), 1,
+      sym_variable_name,
+    STATE(72), 1,
+      sym_identifier,
+    STATE(111), 1,
+      aux_sym_export_repeat1,
+  [2120] = 3,
+    ACTIONS(503), 1,
+      aux_sym_variable_name_token1,
+    STATE(134), 1,
+      sym_variable_name,
+    STATE(82), 2,
+      sym_class_name,
+      aux_sym_inherit_repeat1,
+  [2131] = 3,
+    ACTIONS(478), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(505), 1,
+      aux_sym_addtask_token1,
+    STATE(103), 2,
+      sym_variable_name,
+      aux_sym_export_repeat1,
+  [2142] = 3,
+    ACTIONS(478), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(507), 1,
+      aux_sym_addtask_token1,
+    STATE(103), 2,
+      sym_variable_name,
+      aux_sym_export_repeat1,
+  [2153] = 4,
+    ACTIONS(509), 1,
+      anon_sym_LBRACE,
+    ACTIONS(511), 1,
+      anon_sym_RBRACE,
+    ACTIONS(513), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(163), 1,
+      sym__inline_code_inner,
+  [2166] = 3,
+    ACTIONS(515), 1,
+      aux_sym_variable_name_token1,
+    STATE(136), 1,
+      sym_variable_name,
+    STATE(100), 2,
+      sym_function_name,
+      aux_sym_deltask_repeat1,
+  [2177] = 2,
+    ACTIONS(171), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(173), 3,
+      anon_sym_SQUOTE2,
+      anon_sym_DOLLAR_LBRACE_AT,
+      sym_string_text_fragment2,
+  [2186] = 3,
+    ACTIONS(515), 1,
+      aux_sym_variable_name_token1,
+    STATE(136), 1,
+      sym_variable_name,
+    STATE(99), 2,
+      sym_function_name,
+      aux_sym_deltask_repeat1,
+  [2197] = 4,
+    ACTIONS(509), 1,
+      anon_sym_LBRACE,
+    ACTIONS(517), 1,
+      anon_sym_RBRACE,
+    ACTIONS(519), 1,
+      aux_sym__inline_code_inner_token1,
+    STATE(161), 1,
+      sym__inline_code_inner,
+  [2210] = 4,
+    ACTIONS(521), 1,
+      anon_sym_RBRACE,
+    ACTIONS(523), 1,
+      aux_sym_code_body_token1,
+    STATE(124), 1,
+      aux_sym_code_body_repeat1,
+    STATE(166), 1,
+      sym_code_body,
+  [2223] = 3,
+    ACTIONS(515), 1,
+      aux_sym_variable_name_token1,
+    STATE(136), 1,
+      sym_variable_name,
+    STATE(94), 2,
+      sym_function_name,
+      aux_sym_deltask_repeat1,
+  [2234] = 3,
+    ACTIONS(525), 1,
+      anon_sym_RBRACE,
+    ACTIONS(527), 1,
+      aux_sym_code_body_token1,
+    STATE(119), 1,
+      aux_sym_code_body_repeat1,
+  [2244] = 2,
+    ACTIONS(515), 1,
+      aux_sym_variable_name_token1,
+    STATE(110), 2,
+      sym_variable_name,
+      aux_sym_export_repeat1,
+  [2252] = 2,
+    ACTIONS(532), 1,
+      aux_sym__inline_code_inner_token1,
+    ACTIONS(530), 2,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+  [2260] = 3,
+    ACTIONS(534), 1,
       anon_sym_DQUOTE,
-    ACTIONS(187), 1,
+    ACTIONS(536), 1,
       anon_sym_SQUOTE,
     STATE(26), 1,
       sym_string,
-    STATE(28), 1,
-      sym_string2,
-  [699] = 3,
-    ACTIONS(193), 1,
-      aux_sym_statement_token1,
-    ACTIONS(209), 1,
+  [2270] = 3,
+    ACTIONS(534), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(536), 1,
+      anon_sym_SQUOTE,
+    STATE(33), 1,
+      sym_string,
+  [2280] = 3,
+    ACTIONS(538), 1,
       anon_sym_RBRACE,
-    STATE(40), 2,
-      sym_statement,
-      aux_sym_block_repeat1,
-  [710] = 3,
-    ACTIONS(197), 1,
-      aux_sym_identifier_token1,
-    ACTIONS(211), 1,
-      aux_sym_addtask_token1,
-    STATE(42), 2,
-      sym_identifier,
-      aux_sym_addtask_repeat1,
-  [721] = 3,
-    ACTIONS(213), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(215), 1,
-      aux_sym_string2_token1,
-    STATE(56), 1,
-      aux_sym_string2_repeat1,
-  [731] = 3,
-    ACTIONS(217), 1,
-      aux_sym__require_path_token1,
-    STATE(53), 1,
-      aux_sym__require_path_repeat1,
-    STATE(62), 1,
-      sym__require_path,
-  [741] = 3,
-    ACTIONS(219), 1,
-      anon_sym_LF,
-    ACTIONS(221), 1,
-      aux_sym__require_path_token1,
-    STATE(49), 1,
-      aux_sym__require_path_repeat1,
-  [751] = 2,
-    ACTIONS(73), 1,
-      aux_sym_addtask_token1,
-    ACTIONS(71), 2,
-      anon_sym_COLON,
-      aux_sym_identifier_token1,
-  [759] = 2,
-    ACTIONS(224), 1,
-      aux_sym_identifier_token1,
-    STATE(41), 2,
-      sym_identifier,
-      aux_sym_addtask_repeat1,
-  [767] = 3,
-    ACTIONS(226), 1,
-      aux_sym_identifier_token1,
-    STATE(15), 1,
-      sym_task_declaration,
-    STATE(63), 1,
-      sym_identifier,
-  [777] = 3,
-    ACTIONS(228), 1,
-      anon_sym_LF,
-    ACTIONS(230), 1,
-      aux_sym__require_path_token1,
-    STATE(49), 1,
-      aux_sym__require_path_repeat1,
-  [787] = 3,
-    ACTIONS(232), 1,
-      aux_sym_identifier_token1,
-    STATE(11), 1,
-      sym_identifier,
-    STATE(46), 1,
-      aux_sym_addtask_repeat1,
-  [797] = 3,
-    ACTIONS(234), 1,
-      aux_sym_inherit_token1,
-    ACTIONS(236), 1,
-      anon_sym_LF,
-    STATE(57), 1,
-      aux_sym_inherit_repeat1,
-  [807] = 3,
-    ACTIONS(238), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(240), 1,
-      aux_sym_string2_token1,
-    STATE(56), 1,
-      aux_sym_string2_repeat1,
-  [817] = 3,
-    ACTIONS(243), 1,
-      aux_sym_inherit_token1,
-    ACTIONS(246), 1,
-      anon_sym_LF,
-    STATE(57), 1,
-      aux_sym_inherit_repeat1,
-  [827] = 3,
-    ACTIONS(248), 1,
-      anon_sym_SQUOTE,
-    ACTIONS(250), 1,
-      aux_sym_string2_token1,
-    STATE(47), 1,
-      aux_sym_string2_repeat1,
-  [837] = 2,
-    ACTIONS(252), 1,
-      aux_sym_inherit_token1,
-    STATE(55), 1,
-      aux_sym_inherit_repeat1,
-  [844] = 2,
-    ACTIONS(254), 1,
+    ACTIONS(540), 1,
+      aux_sym_code_body_token1,
+    STATE(119), 1,
+      aux_sym_code_body_repeat1,
+  [2290] = 2,
+    ACTIONS(544), 1,
+      aux_sym__inline_code_inner_token1,
+    ACTIONS(542), 2,
       anon_sym_LBRACE,
-    STATE(20), 1,
+      anon_sym_RBRACE,
+  [2298] = 2,
+    ACTIONS(490), 1,
+      aux_sym_variable_name_token1,
+    STATE(142), 1,
+      sym_variable_name,
+  [2305] = 2,
+    ACTIONS(490), 1,
+      aux_sym_variable_name_token1,
+    STATE(162), 1,
+      sym_variable_name,
+  [2312] = 2,
+    ACTIONS(490), 1,
+      aux_sym_variable_name_token1,
+    STATE(156), 1,
+      sym_variable_name,
+  [2319] = 2,
+    ACTIONS(546), 1,
+      anon_sym_LBRACE,
+    STATE(21), 1,
       sym_block,
-  [851] = 1,
-    ACTIONS(256), 2,
-      anon_sym_RBRACE,
-      aux_sym_statement_token1,
-  [856] = 1,
-    ACTIONS(258), 1,
+  [2326] = 2,
+    ACTIONS(490), 1,
+      aux_sym_variable_name_token1,
+    STATE(154), 1,
+      sym_variable_name,
+  [2333] = 2,
+    ACTIONS(490), 1,
+      aux_sym_variable_name_token1,
+    STATE(152), 1,
+      sym_variable_name,
+  [2340] = 2,
+    ACTIONS(490), 1,
+      aux_sym_variable_name_token1,
+    STATE(150), 1,
+      sym_variable_name,
+  [2347] = 2,
+    ACTIONS(546), 1,
+      anon_sym_LBRACE,
+    STATE(30), 1,
+      sym_block,
+  [2354] = 2,
+    ACTIONS(548), 1,
       anon_sym_LF,
-  [860] = 1,
-    ACTIONS(117), 1,
-      anon_sym_LPAREN,
-  [864] = 1,
-    ACTIONS(260), 1,
-      anon_sym_RPAREN,
-  [868] = 1,
-    ACTIONS(262), 1,
-      ts_builtin_sym_end,
-  [872] = 1,
-    ACTIONS(264), 1,
-      aux_sym_comment_token1,
-  [876] = 1,
-    ACTIONS(266), 1,
-      aux_sym_inherit_token1,
-  [880] = 1,
-    ACTIONS(268), 1,
-      anon_sym_RBRACE,
-  [884] = 1,
-    ACTIONS(270), 1,
+    ACTIONS(550), 1,
+      aux_sym_variable_name_token1,
+  [2361] = 2,
+    ACTIONS(490), 1,
+      aux_sym_variable_name_token1,
+    STATE(148), 1,
+      sym_variable_name,
+  [2368] = 2,
+    ACTIONS(497), 1,
+      aux_sym_variable_name_token1,
+    ACTIONS(499), 1,
       aux_sym_addtask_token1,
-  [888] = 1,
-    ACTIONS(272), 1,
-      aux_sym_override_token1,
-  [892] = 1,
-    ACTIONS(274), 1,
-      aux_sym_string_escape_token1,
-  [896] = 1,
-    ACTIONS(276), 1,
-      aux_sym_string_expansion_token1,
-  [900] = 1,
-    ACTIONS(278), 1,
-      aux_sym_override_token1,
-  [904] = 1,
-    ACTIONS(280), 1,
-      aux_sym_override_token1,
+  [2375] = 2,
+    ACTIONS(490), 1,
+      aux_sym_variable_name_token1,
+    STATE(146), 1,
+      sym_variable_name,
+  [2382] = 2,
+    ACTIONS(490), 1,
+      aux_sym_variable_name_token1,
+    STATE(144), 1,
+      sym_variable_name,
+  [2389] = 2,
+    ACTIONS(546), 1,
+      anon_sym_LBRACE,
+    STATE(40), 1,
+      sym_block,
+  [2396] = 2,
+    ACTIONS(490), 1,
+      aux_sym_variable_name_token1,
+    STATE(158), 1,
+      sym_variable_name,
+  [2403] = 1,
+    ACTIONS(552), 1,
+      anon_sym_RBRACE,
+  [2407] = 1,
+    ACTIONS(554), 1,
+      anon_sym_RBRACE,
+  [2411] = 1,
+    ACTIONS(556), 1,
+      anon_sym_RBRACE,
+  [2415] = 1,
+    ACTIONS(558), 1,
+      anon_sym_RBRACE,
+  [2419] = 1,
+    ACTIONS(560), 1,
+      anon_sym_RBRACE,
+  [2423] = 1,
+    ACTIONS(562), 1,
+      anon_sym_RBRACE,
+  [2427] = 1,
+    ACTIONS(564), 1,
+      anon_sym_RBRACE,
+  [2431] = 1,
+    ACTIONS(566), 1,
+      anon_sym_RBRACE,
+  [2435] = 1,
+    ACTIONS(568), 1,
+      anon_sym_RBRACE,
+  [2439] = 1,
+    ACTIONS(570), 1,
+      anon_sym_RBRACE,
+  [2443] = 1,
+    ACTIONS(572), 1,
+      aux_sym_include_token1,
+  [2447] = 1,
+    ACTIONS(574), 1,
+      anon_sym_RBRACE,
+  [2451] = 1,
+    ACTIONS(576), 1,
+      anon_sym_RBRACE,
+  [2455] = 1,
+    ACTIONS(578), 1,
+      anon_sym_RBRACE,
+  [2459] = 1,
+    ACTIONS(580), 1,
+      anon_sym_RBRACE,
+  [2463] = 1,
+    ACTIONS(582), 1,
+      anon_sym_RBRACE,
+  [2467] = 1,
+    ACTIONS(584), 1,
+      anon_sym_RPAREN,
+  [2471] = 1,
+    ACTIONS(586), 1,
+      anon_sym_RBRACE,
+  [2475] = 1,
+    ACTIONS(588), 1,
+      sym_flag_name,
+  [2479] = 1,
+    ACTIONS(590), 1,
+      anon_sym_RBRACE,
+  [2483] = 1,
+    ACTIONS(592), 1,
+      anon_sym_RBRACE,
+  [2487] = 1,
+    ACTIONS(594), 1,
+      anon_sym_RBRACE,
+  [2491] = 1,
+    ACTIONS(596), 1,
+      anon_sym_RBRACE,
+  [2495] = 1,
+    ACTIONS(598), 1,
+      anon_sym_RBRACE,
+  [2499] = 1,
+    ACTIONS(600), 1,
+      anon_sym_RPAREN,
+  [2503] = 1,
+    ACTIONS(602), 1,
+      anon_sym_RBRACE,
+  [2507] = 1,
+    ACTIONS(532), 1,
+      anon_sym_RBRACE,
+  [2511] = 1,
+    ACTIONS(544), 1,
+      anon_sym_RBRACE,
+  [2515] = 1,
+    ACTIONS(604), 1,
+      anon_sym_RBRACE,
+  [2519] = 1,
+    ACTIONS(606), 1,
+      anon_sym_LPAREN,
+  [2523] = 1,
+    ACTIONS(608), 1,
+      anon_sym_RBRACK,
+  [2527] = 1,
+    ACTIONS(610), 1,
+      anon_sym_RPAREN,
+  [2531] = 1,
+    ACTIONS(612), 1,
+      ts_builtin_sym_end,
+  [2535] = 1,
+    ACTIONS(614), 1,
+      aux_sym_comment_token1,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
-  [SMALL_STATE(3)] = 44,
-  [SMALL_STATE(4)] = 88,
-  [SMALL_STATE(5)] = 110,
-  [SMALL_STATE(6)] = 132,
-  [SMALL_STATE(7)] = 154,
-  [SMALL_STATE(8)] = 175,
-  [SMALL_STATE(9)] = 196,
-  [SMALL_STATE(10)] = 217,
-  [SMALL_STATE(11)] = 233,
-  [SMALL_STATE(12)] = 250,
-  [SMALL_STATE(13)] = 265,
-  [SMALL_STATE(14)] = 279,
-  [SMALL_STATE(15)] = 293,
-  [SMALL_STATE(16)] = 307,
-  [SMALL_STATE(17)] = 321,
-  [SMALL_STATE(18)] = 335,
-  [SMALL_STATE(19)] = 349,
-  [SMALL_STATE(20)] = 363,
-  [SMALL_STATE(21)] = 377,
-  [SMALL_STATE(22)] = 393,
-  [SMALL_STATE(23)] = 407,
-  [SMALL_STATE(24)] = 421,
-  [SMALL_STATE(25)] = 435,
-  [SMALL_STATE(26)] = 449,
-  [SMALL_STATE(27)] = 463,
-  [SMALL_STATE(28)] = 477,
-  [SMALL_STATE(29)] = 491,
-  [SMALL_STATE(30)] = 505,
-  [SMALL_STATE(31)] = 519,
-  [SMALL_STATE(32)] = 537,
-  [SMALL_STATE(33)] = 555,
-  [SMALL_STATE(34)] = 573,
-  [SMALL_STATE(35)] = 587,
-  [SMALL_STATE(36)] = 601,
-  [SMALL_STATE(37)] = 615,
-  [SMALL_STATE(38)] = 622,
-  [SMALL_STATE(39)] = 635,
-  [SMALL_STATE(40)] = 642,
-  [SMALL_STATE(41)] = 653,
-  [SMALL_STATE(42)] = 664,
-  [SMALL_STATE(43)] = 675,
-  [SMALL_STATE(44)] = 686,
-  [SMALL_STATE(45)] = 699,
-  [SMALL_STATE(46)] = 710,
-  [SMALL_STATE(47)] = 721,
-  [SMALL_STATE(48)] = 731,
-  [SMALL_STATE(49)] = 741,
-  [SMALL_STATE(50)] = 751,
-  [SMALL_STATE(51)] = 759,
-  [SMALL_STATE(52)] = 767,
-  [SMALL_STATE(53)] = 777,
-  [SMALL_STATE(54)] = 787,
-  [SMALL_STATE(55)] = 797,
-  [SMALL_STATE(56)] = 807,
-  [SMALL_STATE(57)] = 817,
-  [SMALL_STATE(58)] = 827,
-  [SMALL_STATE(59)] = 837,
-  [SMALL_STATE(60)] = 844,
-  [SMALL_STATE(61)] = 851,
-  [SMALL_STATE(62)] = 856,
-  [SMALL_STATE(63)] = 860,
-  [SMALL_STATE(64)] = 864,
-  [SMALL_STATE(65)] = 868,
-  [SMALL_STATE(66)] = 872,
-  [SMALL_STATE(67)] = 876,
-  [SMALL_STATE(68)] = 880,
-  [SMALL_STATE(69)] = 884,
-  [SMALL_STATE(70)] = 888,
-  [SMALL_STATE(71)] = 892,
-  [SMALL_STATE(72)] = 896,
-  [SMALL_STATE(73)] = 900,
-  [SMALL_STATE(74)] = 904,
+  [SMALL_STATE(3)] = 64,
+  [SMALL_STATE(4)] = 128,
+  [SMALL_STATE(5)] = 164,
+  [SMALL_STATE(6)] = 200,
+  [SMALL_STATE(7)] = 236,
+  [SMALL_STATE(8)] = 271,
+  [SMALL_STATE(9)] = 306,
+  [SMALL_STATE(10)] = 341,
+  [SMALL_STATE(11)] = 373,
+  [SMALL_STATE(12)] = 405,
+  [SMALL_STATE(13)] = 430,
+  [SMALL_STATE(14)] = 455,
+  [SMALL_STATE(15)] = 480,
+  [SMALL_STATE(16)] = 501,
+  [SMALL_STATE(17)] = 522,
+  [SMALL_STATE(18)] = 542,
+  [SMALL_STATE(19)] = 562,
+  [SMALL_STATE(20)] = 592,
+  [SMALL_STATE(21)] = 611,
+  [SMALL_STATE(22)] = 630,
+  [SMALL_STATE(23)] = 649,
+  [SMALL_STATE(24)] = 668,
+  [SMALL_STATE(25)] = 695,
+  [SMALL_STATE(26)] = 714,
+  [SMALL_STATE(27)] = 733,
+  [SMALL_STATE(28)] = 752,
+  [SMALL_STATE(29)] = 771,
+  [SMALL_STATE(30)] = 790,
+  [SMALL_STATE(31)] = 809,
+  [SMALL_STATE(32)] = 828,
+  [SMALL_STATE(33)] = 847,
+  [SMALL_STATE(34)] = 866,
+  [SMALL_STATE(35)] = 885,
+  [SMALL_STATE(36)] = 904,
+  [SMALL_STATE(37)] = 923,
+  [SMALL_STATE(38)] = 942,
+  [SMALL_STATE(39)] = 961,
+  [SMALL_STATE(40)] = 980,
+  [SMALL_STATE(41)] = 999,
+  [SMALL_STATE(42)] = 1027,
+  [SMALL_STATE(43)] = 1055,
+  [SMALL_STATE(44)] = 1079,
+  [SMALL_STATE(45)] = 1103,
+  [SMALL_STATE(46)] = 1131,
+  [SMALL_STATE(47)] = 1155,
+  [SMALL_STATE(48)] = 1176,
+  [SMALL_STATE(49)] = 1201,
+  [SMALL_STATE(50)] = 1222,
+  [SMALL_STATE(51)] = 1246,
+  [SMALL_STATE(52)] = 1270,
+  [SMALL_STATE(53)] = 1294,
+  [SMALL_STATE(54)] = 1318,
+  [SMALL_STATE(55)] = 1342,
+  [SMALL_STATE(56)] = 1366,
+  [SMALL_STATE(57)] = 1381,
+  [SMALL_STATE(58)] = 1404,
+  [SMALL_STATE(59)] = 1427,
+  [SMALL_STATE(60)] = 1447,
+  [SMALL_STATE(61)] = 1463,
+  [SMALL_STATE(62)] = 1477,
+  [SMALL_STATE(63)] = 1491,
+  [SMALL_STATE(64)] = 1510,
+  [SMALL_STATE(65)] = 1529,
+  [SMALL_STATE(66)] = 1548,
+  [SMALL_STATE(67)] = 1567,
+  [SMALL_STATE(68)] = 1586,
+  [SMALL_STATE(69)] = 1599,
+  [SMALL_STATE(70)] = 1612,
+  [SMALL_STATE(71)] = 1625,
+  [SMALL_STATE(72)] = 1638,
+  [SMALL_STATE(73)] = 1651,
+  [SMALL_STATE(74)] = 1670,
+  [SMALL_STATE(75)] = 1688,
+  [SMALL_STATE(76)] = 1706,
+  [SMALL_STATE(77)] = 1717,
+  [SMALL_STATE(78)] = 1732,
+  [SMALL_STATE(79)] = 1743,
+  [SMALL_STATE(80)] = 1754,
+  [SMALL_STATE(81)] = 1765,
+  [SMALL_STATE(82)] = 1779,
+  [SMALL_STATE(83)] = 1793,
+  [SMALL_STATE(84)] = 1807,
+  [SMALL_STATE(85)] = 1821,
+  [SMALL_STATE(86)] = 1835,
+  [SMALL_STATE(87)] = 1849,
+  [SMALL_STATE(88)] = 1863,
+  [SMALL_STATE(89)] = 1873,
+  [SMALL_STATE(90)] = 1887,
+  [SMALL_STATE(91)] = 1901,
+  [SMALL_STATE(92)] = 1915,
+  [SMALL_STATE(93)] = 1929,
+  [SMALL_STATE(94)] = 1943,
+  [SMALL_STATE(95)] = 1957,
+  [SMALL_STATE(96)] = 1967,
+  [SMALL_STATE(97)] = 1977,
+  [SMALL_STATE(98)] = 1991,
+  [SMALL_STATE(99)] = 2005,
+  [SMALL_STATE(100)] = 2019,
+  [SMALL_STATE(101)] = 2033,
+  [SMALL_STATE(102)] = 2047,
+  [SMALL_STATE(103)] = 2060,
+  [SMALL_STATE(104)] = 2071,
+  [SMALL_STATE(105)] = 2080,
+  [SMALL_STATE(106)] = 2089,
+  [SMALL_STATE(107)] = 2098,
+  [SMALL_STATE(108)] = 2107,
+  [SMALL_STATE(109)] = 2120,
+  [SMALL_STATE(110)] = 2131,
+  [SMALL_STATE(111)] = 2142,
+  [SMALL_STATE(112)] = 2153,
+  [SMALL_STATE(113)] = 2166,
+  [SMALL_STATE(114)] = 2177,
+  [SMALL_STATE(115)] = 2186,
+  [SMALL_STATE(116)] = 2197,
+  [SMALL_STATE(117)] = 2210,
+  [SMALL_STATE(118)] = 2223,
+  [SMALL_STATE(119)] = 2234,
+  [SMALL_STATE(120)] = 2244,
+  [SMALL_STATE(121)] = 2252,
+  [SMALL_STATE(122)] = 2260,
+  [SMALL_STATE(123)] = 2270,
+  [SMALL_STATE(124)] = 2280,
+  [SMALL_STATE(125)] = 2290,
+  [SMALL_STATE(126)] = 2298,
+  [SMALL_STATE(127)] = 2305,
+  [SMALL_STATE(128)] = 2312,
+  [SMALL_STATE(129)] = 2319,
+  [SMALL_STATE(130)] = 2326,
+  [SMALL_STATE(131)] = 2333,
+  [SMALL_STATE(132)] = 2340,
+  [SMALL_STATE(133)] = 2347,
+  [SMALL_STATE(134)] = 2354,
+  [SMALL_STATE(135)] = 2361,
+  [SMALL_STATE(136)] = 2368,
+  [SMALL_STATE(137)] = 2375,
+  [SMALL_STATE(138)] = 2382,
+  [SMALL_STATE(139)] = 2389,
+  [SMALL_STATE(140)] = 2396,
+  [SMALL_STATE(141)] = 2403,
+  [SMALL_STATE(142)] = 2407,
+  [SMALL_STATE(143)] = 2411,
+  [SMALL_STATE(144)] = 2415,
+  [SMALL_STATE(145)] = 2419,
+  [SMALL_STATE(146)] = 2423,
+  [SMALL_STATE(147)] = 2427,
+  [SMALL_STATE(148)] = 2431,
+  [SMALL_STATE(149)] = 2435,
+  [SMALL_STATE(150)] = 2439,
+  [SMALL_STATE(151)] = 2443,
+  [SMALL_STATE(152)] = 2447,
+  [SMALL_STATE(153)] = 2451,
+  [SMALL_STATE(154)] = 2455,
+  [SMALL_STATE(155)] = 2459,
+  [SMALL_STATE(156)] = 2463,
+  [SMALL_STATE(157)] = 2467,
+  [SMALL_STATE(158)] = 2471,
+  [SMALL_STATE(159)] = 2475,
+  [SMALL_STATE(160)] = 2479,
+  [SMALL_STATE(161)] = 2483,
+  [SMALL_STATE(162)] = 2487,
+  [SMALL_STATE(163)] = 2491,
+  [SMALL_STATE(164)] = 2495,
+  [SMALL_STATE(165)] = 2499,
+  [SMALL_STATE(166)] = 2503,
+  [SMALL_STATE(167)] = 2507,
+  [SMALL_STATE(168)] = 2511,
+  [SMALL_STATE(169)] = 2515,
+  [SMALL_STATE(170)] = 2519,
+  [SMALL_STATE(171)] = 2523,
+  [SMALL_STATE(172)] = 2527,
+  [SMALL_STATE(173)] = 2531,
+  [SMALL_STATE(174)] = 2535,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0),
-  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
-  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
-  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(59),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(67),
-  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1),
-  [23] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2),
-  [25] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(54),
-  [28] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(52),
-  [31] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(59),
-  [34] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(48),
-  [37] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(51),
-  [40] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(67),
-  [43] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(7),
-  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(66),
-  [49] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_identifier, 1),
-  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1),
-  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
-  [55] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_identifier_repeat1, 2),
-  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_identifier_repeat1, 2),
-  [59] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_identifier_repeat1, 2), SHIFT_REPEAT(73),
-  [62] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_identifier, 2),
-  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 2),
-  [66] = {.entry = {.count = 1, .reusable = false}}, SHIFT(70),
-  [68] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_identifier_repeat1, 2), SHIFT_REPEAT(70),
-  [71] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_override, 2),
-  [73] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_override, 2),
-  [75] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
-  [77] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_addtask_repeat1, 1),
-  [79] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_addtask_repeat1, 1),
-  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string2, 2),
-  [83] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string2, 2),
-  [85] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_export, 3),
-  [87] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_export, 3),
-  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_python_task_declaration, 2),
-  [91] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_python_task_declaration, 2),
-  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string2, 3),
-  [95] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string2, 3),
-  [97] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include, 3),
-  [99] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_include, 3),
-  [101] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3),
-  [103] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
-  [105] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_addtask, 3),
-  [107] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_addtask, 3),
-  [109] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_task_declaration, 4, .production_id = 1),
-  [111] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_task_declaration, 4, .production_id = 1),
-  [113] = {.entry = {.count = 1, .reusable = false}}, SHIFT(38),
-  [115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_require, 3),
-  [121] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_require, 3),
-  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3),
-  [125] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3),
-  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 2),
-  [129] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 2),
-  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2),
-  [133] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
-  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 4),
-  [137] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_declaration, 4),
-  [139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inherit, 3),
-  [141] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inherit, 3),
-  [143] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 1),
-  [145] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 1),
-  [147] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2),
-  [149] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2),
-  [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 3),
-  [153] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_declaration, 3),
-  [155] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [157] = {.entry = {.count = 1, .reusable = false}}, SHIFT(32),
-  [159] = {.entry = {.count = 1, .reusable = false}}, SHIFT(72),
-  [161] = {.entry = {.count = 1, .reusable = false}}, SHIFT(71),
-  [163] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [165] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [167] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2),
-  [169] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2), SHIFT_REPEAT(33),
-  [172] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2), SHIFT_REPEAT(72),
-  [175] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2), SHIFT_REPEAT(71),
-  [178] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
-  [180] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_identifier_repeat1, 2), SHIFT_REPEAT(74),
-  [183] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string_escape, 2),
-  [185] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [189] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string_expansion, 3),
-  [191] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
-  [193] = {.entry = {.count = 1, .reusable = false}}, SHIFT(61),
-  [195] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [197] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
-  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_addtask_repeat1, 2),
-  [201] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_addtask_repeat1, 2), SHIFT_REPEAT(35),
-  [204] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2),
-  [206] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2), SHIFT_REPEAT(61),
-  [209] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [211] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [213] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [215] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [219] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym__require_path_repeat1, 2),
-  [221] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__require_path_repeat1, 2), SHIFT_REPEAT(49),
-  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [228] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__require_path, 1),
-  [230] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
-  [232] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [234] = {.entry = {.count = 1, .reusable = false}}, SHIFT(57),
-  [236] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
-  [238] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_string2_repeat1, 2),
-  [240] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_string2_repeat1, 2), SHIFT_REPEAT(56),
-  [243] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_inherit_repeat1, 2), SHIFT_REPEAT(57),
-  [246] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_inherit_repeat1, 2),
-  [248] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
-  [250] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [252] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [254] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [256] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_statement, 1),
-  [258] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
-  [260] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [262] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [264] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [266] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [268] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [278] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(108),
+  [7] = {.entry = {.count = 1, .reusable = false}}, SHIFT(102),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(109),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(77),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(115),
+  [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(120),
+  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(151),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [25] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2),
+  [31] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(108),
+  [34] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(102),
+  [37] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(109),
+  [40] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(77),
+  [43] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(113),
+  [46] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(115),
+  [49] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(120),
+  [52] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(151),
+  [55] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(118),
+  [58] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(9),
+  [61] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(13),
+  [64] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2), SHIFT_REPEAT(174),
+  [67] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1),
+  [69] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_name, 1),
+  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_name, 1),
+  [73] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [75] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [77] = {.entry = {.count = 1, .reusable = false}}, SHIFT(127),
+  [79] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
+  [81] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_variable_name_repeat1, 2),
+  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2),
+  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(5),
+  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(86),
+  [91] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(127),
+  [94] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(5),
+  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_name, 2),
+  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_name, 2),
+  [101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [103] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
+  [105] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(7),
+  [108] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(91),
+  [111] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(126),
+  [114] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(7),
+  [117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [121] = {.entry = {.count = 1, .reusable = false}}, SHIFT(126),
+  [123] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
+  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [127] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
+  [129] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_override, 2),
+  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_override, 2),
+  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [137] = {.entry = {.count = 1, .reusable = false}}, SHIFT(131),
+  [139] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_override_repeat1, 2),
+  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_override_repeat1, 2),
+  [143] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_override_repeat1, 2), SHIFT_REPEAT(11),
+  [146] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_override_repeat1, 2), SHIFT_REPEAT(98),
+  [149] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_override_repeat1, 2), SHIFT_REPEAT(131),
+  [152] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_python_function, 2),
+  [154] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_python_function, 2),
+  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [158] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_python_function, 1),
+  [160] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_python_function, 1),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [164] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_python_function_repeat1, 2),
+  [166] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_python_function_repeat1, 2),
+  [168] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_python_function_repeat1, 2), SHIFT_REPEAT(14),
+  [171] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_shell_expansion, 3),
+  [173] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_shell_expansion, 3),
+  [175] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_python_expansion, 3),
+  [177] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_python_expansion, 3),
+  [179] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_identifier, 1),
+  [181] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_export_repeat1, 1),
+  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
+  [185] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [187] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_export_repeat1, 1),
+  [189] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2),
+  [191] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2),
+  [193] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_shell_task_declaration, 4, .production_id = 3),
+  [195] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_shell_task_declaration, 4, .production_id = 3),
+  [197] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unset, 3),
+  [199] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_unset, 3),
+  [201] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 1),
+  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_addhandler, 3),
+  [205] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_addhandler, 3),
+  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 4),
+  [209] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_declaration, 4),
+  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_addtask, 3),
+  [213] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_addtask, 3),
+  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 3),
+  [217] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 3),
+  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3),
+  [221] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3),
+  [223] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_python_task_declaration, 5, .production_id = 4),
+  [225] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_python_task_declaration, 5, .production_id = 4),
+  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inherit, 3),
+  [229] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inherit, 3),
+  [231] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_declaration, 3),
+  [233] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_declaration, 3),
+  [235] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_include, 4, .production_id = 2),
+  [237] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_include, 4, .production_id = 2),
+  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_export, 3),
+  [241] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_export, 3),
+  [243] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comment, 2),
+  [245] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comment, 2),
+  [247] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2),
+  [249] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2),
+  [251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_deltask, 3),
+  [253] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_deltask, 3),
+  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_export_functions, 3),
+  [257] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_export_functions, 3),
+  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_python_task_declaration, 4),
+  [261] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_python_task_declaration, 4),
+  [263] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(41),
+  [266] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(87),
+  [269] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(137),
+  [272] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(41),
+  [275] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [277] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [279] = {.entry = {.count = 1, .reusable = false}}, SHIFT(137),
+  [281] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [283] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [285] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [287] = {.entry = {.count = 1, .reusable = false}}, SHIFT(140),
+  [289] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [293] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [295] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(46),
+  [298] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(81),
+  [301] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(140),
+  [304] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_identifier, 2),
+  [306] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_identifier, 2),
+  [308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [310] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
+  [312] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
+  [314] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_identifier_repeat1, 2),
+  [316] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_identifier_repeat1, 2),
+  [318] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_identifier_repeat1, 2), SHIFT_REPEAT(48),
+  [321] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [323] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
+  [325] = {.entry = {.count = 1, .reusable = false}}, SHIFT(135),
+  [327] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [329] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(52),
+  [332] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(85),
+  [335] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(138),
+  [338] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [340] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [342] = {.entry = {.count = 1, .reusable = false}}, SHIFT(138),
+  [344] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [346] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(55),
+  [349] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(92),
+  [352] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_variable_name_repeat1, 2), SHIFT_REPEAT(135),
+  [355] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_include_repeat1, 2),
+  [357] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_include_repeat1, 2), SHIFT_REPEAT(96),
+  [360] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_include_repeat1, 2), SHIFT_REPEAT(97),
+  [363] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_include_repeat1, 2), SHIFT_REPEAT(132),
+  [366] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [368] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
+  [370] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
+  [372] = {.entry = {.count = 1, .reusable = false}}, SHIFT(132),
+  [374] = {.entry = {.count = 1, .reusable = false}}, SHIFT(123),
+  [376] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
+  [378] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
+  [380] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_flag, 3),
+  [382] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_flag, 3),
+  [384] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [386] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [388] = {.entry = {.count = 1, .reusable = false}}, SHIFT(130),
+  [390] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [392] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [394] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [396] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [398] = {.entry = {.count = 1, .reusable = false}}, SHIFT(128),
+  [400] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [402] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__string_inner2, 2),
+  [404] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__string_inner2, 2), SHIFT_REPEAT(84),
+  [407] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__string_inner2, 2), SHIFT_REPEAT(128),
+  [410] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__string_inner2, 2), SHIFT_REPEAT(66),
+  [413] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__string_inner1, 2),
+  [415] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__string_inner1, 2), SHIFT_REPEAT(101),
+  [418] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym__string_inner1, 2), SHIFT_REPEAT(130),
+  [421] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__string_inner1, 2), SHIFT_REPEAT(67),
+  [424] = {.entry = {.count = 1, .reusable = false}}, SHIFT(122),
+  [426] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [428] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [430] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
+  [432] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
+  [434] = {.entry = {.count = 1, .reusable = false}}, SHIFT(42),
+  [436] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_addtask_repeat1, 2), SHIFT_REPEAT(75),
+  [439] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_addtask_repeat1, 2),
+  [441] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_addtask_repeat1, 2), SHIFT_REPEAT(42),
+  [444] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
+  [446] = {.entry = {.count = 1, .reusable = false}}, SHIFT(112),
+  [448] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [450] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [452] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
+  [454] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_inline_code_repeat1, 2), SHIFT_REPEAT(112),
+  [457] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_inline_code_repeat1, 2),
+  [459] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_inline_code_repeat1, 2), SHIFT_REPEAT(83),
+  [462] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_inherit_repeat1, 2),
+  [464] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_inherit_repeat1, 2), SHIFT_REPEAT(54),
+  [467] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_code, 1),
+  [469] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [471] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_deltask_repeat1, 2),
+  [473] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_deltask_repeat1, 2), SHIFT_REPEAT(50),
+  [476] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [478] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
+  [480] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_include_repeat1, 1),
+  [482] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_include_repeat1, 1),
+  [484] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [486] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [488] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [490] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [492] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_export_repeat1, 2),
+  [494] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_export_repeat1, 2), SHIFT_REPEAT(50),
+  [497] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_name, 1, .production_id = 1),
+  [499] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_name, 1, .production_id = 1),
+  [501] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [503] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [505] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [507] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [509] = {.entry = {.count = 1, .reusable = false}}, SHIFT(116),
+  [511] = {.entry = {.count = 1, .reusable = false}}, SHIFT(121),
+  [513] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
+  [515] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [517] = {.entry = {.count = 1, .reusable = false}}, SHIFT(167),
+  [519] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
+  [521] = {.entry = {.count = 1, .reusable = false}}, SHIFT(20),
+  [523] = {.entry = {.count = 1, .reusable = false}}, SHIFT(124),
+  [525] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_code_body_repeat1, 2),
+  [527] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_code_body_repeat1, 2), SHIFT_REPEAT(119),
+  [530] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__inline_code_inner, 2),
+  [532] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__inline_code_inner, 2),
+  [534] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [536] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [538] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_code_body, 1),
+  [540] = {.entry = {.count = 1, .reusable = false}}, SHIFT(119),
+  [542] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__inline_code_inner, 3),
+  [544] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__inline_code_inner, 3),
+  [546] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
+  [548] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_name, 1, .production_id = 1),
+  [550] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_name, 1, .production_id = 1),
+  [552] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [554] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [556] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [558] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
+  [560] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [562] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [564] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [566] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [568] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [570] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [572] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [574] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [576] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [578] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
+  [580] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [582] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
+  [584] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [586] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [588] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
+  [590] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [592] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
+  [594] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [596] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
+  [598] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [600] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
+  [602] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [604] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [606] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [608] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [610] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
+  [612] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [614] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/expansion.txt
+++ b/test/corpus/expansion.txt
@@ -1,0 +1,141 @@
+================
+Simple expansion
+================
+
+A = "${hello}"
+B = 'A${hello}'
+C = "${hello}B"
+D = 'C${hello}D'
+
+---
+
+(source_file
+  (variable_declaration
+    (identifier (variable_name))
+    (string
+      (shell_expansion (variable_name))))
+  (variable_declaration
+    (identifier (variable_name))
+    (string
+      (string_text_fragment)
+      (shell_expansion (variable_name))))
+  (variable_declaration
+    (identifier (variable_name))
+    (string
+      (shell_expansion (variable_name))
+      (string_text_fragment)))
+  (variable_declaration
+    (identifier (variable_name))
+    (string
+      (string_text_fragment)
+      (shell_expansion (variable_name))
+      (string_text_fragment))))
+
+================
+Python expansion
+================
+
+A = "${@hello}"
+B = '${@hello.world()}'
+C = "${@hello.world({})}"
+D = '${@hello.world({C})}'
+
+---
+
+(source_file
+  (variable_declaration
+    (identifier (variable_name))
+    (string
+      (python_expansion (inline_code))))
+  (variable_declaration
+    (identifier (variable_name))
+    (string
+      (python_expansion (inline_code))))
+  (variable_declaration
+    (identifier (variable_name))
+    (string
+      (python_expansion (inline_code))))
+  (variable_declaration
+    (identifier (variable_name))
+    (string
+      (python_expansion (inline_code)))))
+
+===================
+Recursive expansion
+===================
+
+A = "${hello}"
+B = "${A${A}}"
+C = "${A${A${A}}}"
+
+---
+
+(source_file
+  (variable_declaration
+    (identifier (variable_name))
+    (string
+      (shell_expansion (variable_name))))
+  (variable_declaration
+    (identifier (variable_name))
+    (string
+      (shell_expansion
+        (variable_name
+          (shell_expansion
+            (variable_name))))))
+  (variable_declaration
+    (identifier (variable_name))
+    (string
+      (shell_expansion
+        (variable_name
+          (shell_expansion
+            (variable_name
+              (shell_expansion
+                (variable_name)))))))))
+
+====================
+Identifier expansion
+====================
+
+A${B} = "hello"
+A${B}C = "hello"
+A${@B}C = "hello"
+
+---
+
+(source_file
+  (variable_declaration
+    (identifier (variable_name (shell_expansion (variable_name))))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier (variable_name (shell_expansion (variable_name))))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier (variable_name (python_expansion (inline_code))))
+    (string (string_text_fragment))))
+
+==================
+Override expansion
+==================
+
+A:${B} = "hello"
+A:${B}C = "hello"
+A:${@B}C = "hello"
+
+---
+
+(source_file
+  (variable_declaration
+    (identifier
+      (variable_name)
+      (override (shell_expansion (variable_name))))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier
+      (variable_name)
+      (override (shell_expansion (variable_name))))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier
+      (variable_name)
+      (override (python_expansion (inline_code))))
+    (string (string_text_fragment))))

--- a/test/corpus/hello_world.txt
+++ b/test/corpus/hello_world.txt
@@ -1,0 +1,128 @@
+============
+bitbake.conf
+============
+
+PN  = "${@bb.parse.vars_from_file(d.getVar('FILE', False),d)[0] or 'defaultpkgname'}"
+
+TMPDIR  = "${TOPDIR}/tmp"
+CACHE   = "${TMPDIR}/cache"
+STAMP   = "${TMPDIR}/${PN}/stamps"
+T       = "${TMPDIR}/${PN}/work"
+B       = "${TMPDIR}/${PN}"
+
+---
+
+(source_file
+	(variable_declaration
+		(identifier (variable_name))
+		(string
+			(python_expansion (inline_code))))
+	(variable_declaration
+		(identifier (variable_name))
+		(string
+			(shell_expansion (variable_name))
+			(string_text_fragment)))
+	(variable_declaration
+		(identifier (variable_name))
+		(string
+			(shell_expansion (variable_name))
+			(string_text_fragment)))
+	(variable_declaration
+		(identifier (variable_name))
+		(string
+			(shell_expansion (variable_name))
+			(string_text_fragment)
+			(shell_expansion (variable_name))
+			(string_text_fragment)))
+	(variable_declaration
+		(identifier (variable_name))
+		(string
+			(shell_expansion (variable_name))
+			(string_text_fragment)
+			(shell_expansion (variable_name))
+			(string_text_fragment)))
+	(variable_declaration
+		(identifier (variable_name))
+		(string
+			(shell_expansion (variable_name))
+			(string_text_fragment)
+			(shell_expansion (variable_name)))))
+
+==========
+layer.conf
+==========
+
+BBPATH .= ":${LAYERDIR}"
+BBFILES += "${LAYERDIR}/*.bb"
+BBFILE_COLLECTIONS += "mylayer"
+BBFILE_PATTERN_mylayer := "^${LAYERDIR_RE}/"
+
+---
+
+(source_file
+	(variable_declaration
+		(identifier (variable_name))
+		(string
+			(string_text_fragment)
+			(shell_expansion (variable_name))))
+	(variable_declaration
+		(identifier (variable_name))
+		(string
+			(shell_expansion (variable_name))
+			(string_text_fragment)))
+	(variable_declaration
+		(identifier (variable_name))
+		(string (string_text_fragment)))
+	(variable_declaration
+		(identifier (variable_name))
+		(string
+			(string_text_fragment)
+			(shell_expansion (variable_name))
+			(string_text_fragment))))
+
+=============
+printhello.bb
+=============
+
+DESCRIPTION = "Prints Hello World"
+PN = 'printhello'
+PV = '1'
+
+python do_build() {
+   bb.plain("********************");
+   bb.plain("*                  *");
+   bb.plain("*  Hello, World!   *");
+   bb.plain("*                  *");
+   bb.plain("********************");
+}
+
+---
+
+(source_file
+	(variable_declaration
+		(identifier (variable_name))
+		(string (string_text_fragment)))
+	(variable_declaration
+		(identifier (variable_name))
+		(string (string_text_fragment)))
+	(variable_declaration
+		(identifier (variable_name))
+		(string (string_text_fragment)))
+	(python_task_declaration
+		name: (identifier (variable_name))
+		(block (code_body))))
+
+=============
+bblayers.conf
+=============
+
+BBLAYERS ?= " \
+    /home/<you>/mylayer \
+"
+
+---
+
+(source_file
+	(variable_declaration
+		(identifier (variable_name))
+		(string (string_text_fragment))))

--- a/test/corpus/include.txt
+++ b/test/corpus/include.txt
@@ -1,0 +1,24 @@
+==================
+Include Statements
+==================
+
+include thing
+require thing
+include path/to/thing.bbinc
+require path/to/thing.bbinc
+include with${expansion}.bbinc
+require with${expansion}.bbinc
+
+---
+
+(source_file
+  (include (path))
+  (include (path))
+  (include (path))
+  (include (path))
+  (include
+    (path
+      (shell_expansion (variable_name))))
+  (include
+    (path
+      (shell_expansion (variable_name)))))

--- a/test/corpus/inherit.txt
+++ b/test/corpus/inherit.txt
@@ -3,9 +3,14 @@ Inherit Statements
 ==================
 
 inherit cmake
+inherit one two three
 
 ---
 
 (source_file
   (inherit
-    (identifier)))
+    (class_name))
+  (inherit
+    (class_name)
+    (class_name)
+    (class_name)))

--- a/test/corpus/python_def.txt
+++ b/test/corpus/python_def.txt
@@ -1,0 +1,23 @@
+==========
+Python def
+==========
+
+def thing():
+    bb.plain("hello, world")
+
+    bb.plain("hello, world")
+
+    if thing:
+        bb.plain("hello, world")
+
+    # Python comment
+    bb.plain("hello, world")
+A = "back to normal"
+
+---
+
+(source_file
+  (python_function)
+  (variable_declaration
+    (identifier (variable_name))
+    (string (string_text_fragment))))

--- a/test/corpus/task_decl.txt
+++ b/test/corpus/task_decl.txt
@@ -1,6 +1,6 @@
-==================
+================
 Task Declaration
-==================
+================
 
 do_configure:prepend() {
     sed -i s:\ lib/cmake:\ ${baselib}/cmake:g ${S}/src/CMakeLists.txt
@@ -9,8 +9,42 @@ do_configure:prepend() {
 ---
 
 (source_file
-  (task_declaration
+  (shell_task_declaration
     (identifier
+      (variable_name)
       (override))
     (block
-      (statement))))
+      (code_body))))
+
+=======================
+Python Task Declaration
+=======================
+
+python do_configure:prepend() {
+    bb.plain("hello")
+}
+
+---
+
+(source_file
+  (python_task_declaration
+    (identifier
+      (variable_name)
+      (override))
+    (block
+      (code_body))))
+
+=================================
+Anonymous Python Task Declaration
+=================================
+
+python() {
+    bb.plain("hello")
+}
+
+---
+
+(source_file
+  (python_task_declaration
+    (block
+      (code_body))))

--- a/test/corpus/variable_decl.txt
+++ b/test/corpus/variable_decl.txt
@@ -1,12 +1,116 @@
-==================
+====================
 Variable Declaration
-==================
+====================
 
 LICENSE = "EPL-2.0 | EDL-1.0"
+A = "world's hello"
+B = '"hello, world"'
 
 ---
 
 (source_file
   (variable_declaration
-    (identifier)
-    (string)))
+    (identifier (variable_name))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier (variable_name))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier (variable_name))
+    (string (string_text_fragment))))
+
+=================
+Multiline strings
+=================
+
+A = "\
+hello"
+B = ' \
+hello'
+C = "hello\
+"
+D = ' \
+hello \
+'
+E = "\
+"
+F = ' \
+'
+G = " \
+  hello \
+  world \
+  bla \
+"
+
+---
+
+(source_file
+  (variable_declaration
+    (identifier (variable_name))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier (variable_name))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier (variable_name))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier (variable_name))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier (variable_name))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier (variable_name))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier (variable_name))
+    (string (string_text_fragment))))
+
+=========
+Overrides
+=========
+
+A:hello = "world"
+A:append = "world"
+A:prepend = "world"
+A:remove = "world"
+
+---
+
+(source_file
+  (variable_declaration
+    (identifier
+      (variable_name)
+      (override))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier
+      (variable_name)
+      (override))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier
+      (variable_name)
+      (override))
+    (string (string_text_fragment)))
+  (variable_declaration
+    (identifier
+      (variable_name)
+      (override))
+    (string (string_text_fragment))))
+
+=====
+Flags
+=====
+
+A[hello] = "world"
+
+---
+
+(source_file
+  (variable_declaration
+    (identifier
+      (variable_name)
+      (flag (flag_name)))
+    (string (string_text_fragment))))


### PR DESCRIPTION
Hello ! I found myself in need of the Bitbake syntax support, and I found your nice project. I took the liberty of trying to fix the limitations you wrote in your readme, enough for using this project on a day to day basis.

Current limitations:

- Starting with an expansion in a variable declaration:

```bash
${THING}_REST = "hello"
```

This is due to a collision I can't quite figure out (you can try removing line 181 to see for yourself). I'm not sure whether that's allowed / used in the Bitbake syntax.

- Python syntax highlighting in a shell task:

```bash
thing() {
    echo "${@str(2 + 2)}"
}
```

I'm not sure if this is even possible to have the bash injection, plus still the Python injection over it in this case.